### PR TITLE
Formalize aws access control for lws

### DIFF
--- a/lws-access-control-policies.md
+++ b/lws-access-control-policies.md
@@ -1,0 +1,569 @@
+# Access Control Policies for Linked Web Storage
+
+## Executive Summary
+
+This document provides a comprehensive analysis of access control mechanisms across major cloud storage providers and existing Solid specifications (WAC and ACP), proposing a unified access control model for the Linked Web Storage (LWS) specification that can be adopted by all drive providers while maintaining compatibility with existing systems.
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [Analysis of Existing Access Control Systems](#analysis-of-existing-access-control-systems)
+3. [Common Patterns and Requirements](#common-patterns-and-requirements)
+4. [Proposed LWS Access Control Model](#proposed-lws-access-control-model)
+5. [Implementation Considerations](#implementation-considerations)
+6. [Migration Path](#migration-path)
+7. [Security Considerations](#security-considerations)
+8. [Appendices](#appendices)
+
+## Introduction
+
+The Linked Web Storage (LWS) specification aims to provide a standardized interface for personal cloud storage that can be implemented by existing providers while supporting advanced features like semantic data sharing and agentic access. A critical component of this specification is a unified access control model that:
+
+1. Can be implemented by major cloud storage providers (Google Drive, Microsoft OneDrive, Dropbox, AWS S3, etc.)
+2. Supports the rich access control features of Solid (WAC and ACP)
+3. Enables fine-grained permissions suitable for agentic access
+4. Maintains backward compatibility with existing systems
+5. Supports credential storage use cases
+
+## Analysis of Existing Access Control Systems
+
+### 1. Google Drive
+
+**Key Features:**
+- Role-based permissions: owner, organizer, fileOrganizer, writer, commenter, reader
+- File and folder-level permissions
+- Domain-wide sharing capabilities
+- Link sharing with expiration dates
+- Permission inheritance from parent folders
+- Supports both user and group principals
+
+**API Model:**
+```json
+{
+  "kind": "drive#permission",
+  "id": "string",
+  "type": "user|group|domain|anyone",
+  "role": "owner|organizer|fileOrganizer|writer|commenter|reader",
+  "emailAddress": "string",
+  "domain": "string",
+  "allowFileDiscovery": boolean,
+  "expirationTime": "datetime"
+}
+```
+
+### 2. Microsoft OneDrive (Graph API)
+
+**Key Features:**
+- Role-based permissions: owner, write, read
+- Sharing links with various permission levels
+- Inheritance from parent containers
+- Integration with Azure AD for enterprise scenarios
+- Support for anonymous sharing via links
+- Granular permissions through SharePoint integration
+
+**API Model:**
+```json
+{
+  "id": "string",
+  "roles": ["read", "write", "owner"],
+  "grantedTo": {
+    "user": {
+      "id": "string",
+      "displayName": "string"
+    }
+  },
+  "link": {
+    "type": "view|edit|embed",
+    "scope": "anonymous|organization|users"
+  }
+}
+```
+
+### 3. Dropbox
+
+**Key Features:**
+- Member-based permissions: owner, editor, viewer
+- Folder and file-level access control
+- Shared folder membership
+- Link sharing with passwords and expiration
+- Team folders with inherited permissions
+- Viewer info restrictions
+
+**API Model:**
+```json
+{
+  "access_type": {
+    ".tag": "owner|editor|viewer"
+  },
+  "user": {
+    "account_id": "string",
+    "email": "string"
+  },
+  "permissions": ["can_edit", "can_share", "can_view_metadata"],
+  "is_inherited": boolean
+}
+```
+
+### 4. AWS S3
+
+**Key Features:**
+- IAM policies with fine-grained actions
+- Bucket policies for resource-based permissions
+- Access Control Lists (ACLs) for legacy support
+- Condition-based access control
+- Cross-account access
+- Temporary credentials via STS
+
+**Policy Model:**
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow|Deny",
+    "Principal": {"AWS": ["arn:aws:iam::123456789012:user/username"]},
+    "Action": ["s3:GetObject", "s3:PutObject"],
+    "Resource": ["arn:aws:s3:::bucket-name/*"],
+    "Condition": {
+      "StringEquals": {
+        "s3:x-amz-acl": "public-read"
+      }
+    }
+  }]
+}
+```
+
+### 5. Solid Web Access Control (WAC)
+
+**Key Features:**
+- RDF-based access control
+- Mode-based permissions: Read, Write, Append, Control
+- Agent classes: Agent, AuthenticatedAgent, Origin
+- Inheritance through default rules
+- Resource and container-level controls
+
+**RDF Model:**
+```turtle
+@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+
+<#authorization>
+    a acl:Authorization;
+    acl:agent <https://alice.example/profile#me>;
+    acl:mode acl:Read, acl:Write;
+    acl:accessTo <./resource.ttl>.
+```
+
+### 6. Solid Access Control Policy (ACP)
+
+**Key Features:**
+- Policy-based access control
+- Matcher-based agent selection
+- Allow/deny semantics
+- Context-aware access control
+- Verifiable Credentials support
+- Policy composition and reuse
+
+**RDF Model:**
+```turtle
+@prefix acp: <http://www.w3.org/ns/solid/acp#>.
+
+<#policy>
+    a acp:Policy;
+    acp:allow acl:Read;
+    acp:anyOf [
+        acp:agent <https://alice.example/profile#me>
+    ].
+```
+
+## Common Patterns and Requirements
+
+### Universal Concepts
+
+1. **Principals/Agents**
+   - Individual users (authenticated by various means)
+   - Groups/teams
+   - Applications/services
+   - Anonymous/public access
+   - Authenticated but unspecified users
+
+2. **Permissions/Modes**
+   - Read (view content)
+   - Write (modify content)
+   - Delete (remove content)
+   - Share (grant permissions to others)
+   - Control/Admin (modify access control)
+
+3. **Resources**
+   - Individual files/documents
+   - Folders/containers
+   - Metadata
+   - Access control resources themselves
+
+4. **Inheritance**
+   - All systems support some form of permission inheritance
+   - Parent-to-child propagation is standard
+   - Override mechanisms vary
+
+### Divergent Approaches
+
+1. **Grant Model**
+   - Role-based (Google, OneDrive, Dropbox)
+   - Action-based (AWS S3)
+   - Mode-based (Solid WAC/ACP)
+
+2. **Policy Evaluation**
+   - Implicit deny (most providers)
+   - Explicit allow/deny (AWS S3, ACP)
+   - Default inheritance rules vary
+
+3. **Sharing Mechanisms**
+   - Direct user grants
+   - Shareable links
+   - Token-based access
+   - Credential-based access
+
+## Proposed LWS Access Control Model
+
+### Design Principles
+
+1. **Compatibility First**: The model must be implementable as a facade over existing provider APIs
+2. **Semantic Clarity**: Use RDF/Linked Data for interoperability
+3. **Progressive Enhancement**: Support basic features universally, advanced features optionally
+4. **Security by Default**: Fail closed, explicit grants required
+5. **Auditability**: Clear authorization paths
+
+### Core Vocabulary
+
+```turtle
+@prefix lws: <http://www.w3.org/ns/lws#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Core Classes
+lws:Authorization a rdfs:Class ;
+    rdfs:label "Authorization" ;
+    rdfs:comment "A grant of access to a resource" .
+
+lws:Policy a rdfs:Class ;
+    rdfs:label "Policy" ;
+    rdfs:comment "A reusable access control policy" .
+
+lws:Principal a rdfs:Class ;
+    rdfs:label "Principal" ;
+    rdfs:comment "An entity that can be granted access" .
+
+lws:Resource a rdfs:Class ;
+    rdfs:label "Resource" ;
+    rdfs:comment "A resource that can be accessed" .
+
+# Permission Modes (Core Set)
+lws:Read a lws:PermissionMode ;
+    rdfs:label "Read" ;
+    rdfs:comment "Permission to read/view resource content" .
+
+lws:Write a lws:PermissionMode ;
+    rdfs:label "Write" ;
+    rdfs:comment "Permission to modify resource content" .
+
+lws:Append a lws:PermissionMode ;
+    rdfs:label "Append" ;
+    rdfs:comment "Permission to add to resource content" ;
+    rdfs:subClassOf lws:Write .
+
+lws:Delete a lws:PermissionMode ;
+    rdfs:label "Delete" ;
+    rdfs:comment "Permission to remove resources" .
+
+lws:Control a lws:PermissionMode ;
+    rdfs:label "Control" ;
+    rdfs:comment "Permission to modify access control" .
+
+# Properties
+lws:grantedTo a rdf:Property ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range lws:Principal .
+
+lws:grants a rdf:Property ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range lws:PermissionMode .
+
+lws:target a rdf:Property ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range lws:Resource .
+
+lws:inheritsFrom a rdf:Property ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range lws:Authorization .
+
+lws:validFrom a rdf:Property ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range xsd:dateTime .
+
+lws:validUntil a rdf:Property ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range xsd:dateTime .
+```
+
+### Authorization Model
+
+#### Basic Authorization
+
+```turtle
+# Simple read access grant
+<#auth1> a lws:Authorization ;
+    lws:grantedTo <https://alice.example/profile#me> ;
+    lws:grants lws:Read ;
+    lws:target </storage/documents/report.pdf> .
+
+# Group write access with expiration
+<#auth2> a lws:Authorization ;
+    lws:grantedTo <https://example.org/groups/editors> ;
+    lws:grants lws:Read, lws:Write ;
+    lws:target </storage/documents/> ;
+    lws:validUntil "2024-12-31T23:59:59Z"^^xsd:dateTime .
+```
+
+#### Provider Mappings
+
+| LWS Mode | Google Drive | OneDrive | Dropbox | AWS S3 | WAC | ACP |
+|----------|--------------|----------|---------|---------|-----|-----|
+| Read | reader | read | viewer | s3:GetObject | acl:Read | acp:Read |
+| Write | writer | write | editor | s3:PutObject | acl:Write | acp:Write |
+| Append | writer | write | editor | s3:PutObject | acl:Append | acp:Append |
+| Delete | writer | write | editor | s3:DeleteObject | acl:Write | acp:Write |
+| Control | owner | owner | owner | s3:PutBucketAcl | acl:Control | acp:Control |
+
+### Advanced Features
+
+#### 1. Conditional Access
+
+```turtle
+<#conditional-auth> a lws:Authorization ;
+    lws:grantedTo lws:AuthenticatedAgent ;
+    lws:grants lws:Read ;
+    lws:target </storage/public/> ;
+    lws:condition [
+        lws:ipRange "192.168.1.0/24" ;
+        lws:validDuring lws:BusinessHours
+    ] .
+```
+
+#### 2. Delegated Access
+
+```turtle
+<#delegated-auth> a lws:Authorization ;
+    lws:grantedTo <https://app.example/> ;
+    lws:grants lws:Read, lws:Write ;
+    lws:target </storage/app-data/> ;
+    lws:onBehalfOf <https://alice.example/profile#me> ;
+    lws:scope "calendar.read calendar.write" .
+```
+
+#### 3. Policy-Based Access
+
+```turtle
+<#policy1> a lws:Policy ;
+    rdfs:label "Company Editors Policy" ;
+    lws:grants lws:Read, lws:Write ;
+    lws:condition [
+        lws:memberOf <https://example.org/groups/employees> ;
+        lws:emailDomain "example.org"
+    ] .
+
+<#auth3> a lws:Authorization ;
+    lws:usePolicy <#policy1> ;
+    lws:target </storage/company-docs/> .
+```
+
+### Access Evaluation Algorithm
+
+```text
+function evaluateAccess(principal, resource, mode):
+    authorizations = findAuthorizations(resource)
+    
+    for auth in authorizations:
+        if matchesPrincipal(auth, principal) and 
+           grantsMode(auth, mode) and
+           isValid(auth):
+            if meetsConditions(auth, context):
+                return ALLOW
+    
+    # Check inherited authorizations
+    if parent = getParent(resource):
+        return evaluateAccess(principal, parent, mode)
+    
+    return DENY
+```
+
+## Implementation Considerations
+
+### 1. Provider Adapters
+
+Each storage provider needs an adapter that:
+- Translates LWS authorization to native permissions
+- Maps native permissions to LWS model
+- Handles capability differences gracefully
+
+Example adapter interface:
+```typescript
+interface LWSAdapter {
+  // Convert LWS authorization to provider-specific format
+  toProviderAuth(auth: LWSAuthorization): ProviderPermission;
+  
+  // Convert provider permissions to LWS format
+  fromProviderAuth(perm: ProviderPermission): LWSAuthorization;
+  
+  // Check if provider supports specific LWS features
+  supportsFeature(feature: LWSFeature): boolean;
+  
+  // Apply authorization changes
+  applyAuthorization(auth: LWSAuthorization): Promise<void>;
+}
+```
+
+### 2. Capability Negotiation
+
+Providers should advertise their capabilities:
+
+```turtle
+<https://storage.example/> a lws:StorageProvider ;
+    lws:supportsMode lws:Read, lws:Write, lws:Delete, lws:Control ;
+    lws:supportsFeature lws:ConditionalAccess, lws:GroupPrincipals ;
+    lws:maxPrincipalsPerResource 100 ;
+    lws:supportsInheritance true .
+```
+
+### 3. Performance Optimization
+
+- Cache authorization decisions
+- Batch permission checks
+- Use provider-native bulk operations where available
+- Implement efficient inheritance resolution
+
+### 4. Audit and Compliance
+
+```turtle
+<#audit-entry> a lws:AuditEntry ;
+    lws:timestamp "2024-01-15T10:30:00Z"^^xsd:dateTime ;
+    lws:principal <https://alice.example/profile#me> ;
+    lws:action lws:Read ;
+    lws:resource </storage/documents/sensitive.pdf> ;
+    lws:result lws:Allowed ;
+    lws:authorization <#auth1> .
+```
+
+## Migration Path
+
+### Phase 1: Basic Compatibility (Months 1-3)
+- Implement core permission modes (Read, Write, Delete)
+- Support user and group principals
+- Basic resource-level permissions
+
+### Phase 2: Enhanced Features (Months 4-6)
+- Add Append and Control modes
+- Implement inheritance
+- Support time-based access
+
+### Phase 3: Advanced Capabilities (Months 7-12)
+- Conditional access
+- Policy-based authorization
+- Verifiable credentials integration
+
+### Migration Tools
+
+1. **Permission Mapper**: Converts existing provider permissions to LWS format
+2. **Compatibility Checker**: Validates LWS policies against provider capabilities
+3. **Batch Migrator**: Bulk permission migration utilities
+
+## Security Considerations
+
+### 1. Principle of Least Privilege
+- Default to minimal access
+- Require explicit grants
+- Regular permission audits
+
+### 2. Defense in Depth
+- Multiple authorization checks
+- Provider-level and LWS-level validation
+- Fail-safe defaults
+
+### 3. Attack Vectors
+- **Privilege Escalation**: Prevented by Control mode separation
+- **Inheritance Abuse**: Limited inheritance depth
+- **Timing Attacks**: Consistent evaluation time
+- **Delegation Chains**: Maximum delegation depth
+
+### 4. Privacy Considerations
+- Minimal principal information exposure
+- Anonymous access options
+- Audit log access controls
+
+## Appendices
+
+### Appendix A: Complete LWS Access Control Vocabulary
+
+[Full RDF vocabulary definition would go here]
+
+### Appendix B: Provider-Specific Mapping Tables
+
+[Detailed mapping tables for each provider]
+
+### Appendix C: Example Scenarios
+
+#### Scenario 1: Personal Document Sharing
+```turtle
+# Alice shares a document with Bob for review
+<#share1> a lws:Authorization ;
+    lws:grantedTo <https://bob.example/profile#me> ;
+    lws:grants lws:Read ;
+    lws:target </alice/documents/proposal.pdf> ;
+    lws:validUntil "2024-02-01T00:00:00Z"^^xsd:dateTime ;
+    lws:note "For review - comments welcome" .
+```
+
+#### Scenario 2: Application Data Access
+```turtle
+# Calendar app gets access to calendar data
+<#app-auth> a lws:Authorization ;
+    lws:grantedTo <https://calendar.app/> ;
+    lws:grants lws:Read, lws:Write ;
+    lws:target </alice/data/calendar/> ;
+    lws:onBehalfOf <https://alice.example/profile#me> ;
+    lws:scope "calendar.read calendar.write" .
+```
+
+#### Scenario 3: Organization-Wide Policy
+```turtle
+# All employees can read company handbook
+<#company-policy> a lws:Policy ;
+    rdfs:label "Employee Handbook Access" ;
+    lws:grants lws:Read ;
+    lws:principalClass [
+        a lws:GroupMembership ;
+        lws:group <https://acme.corp/groups/all-employees>
+    ] .
+
+<#handbook-auth> a lws:Authorization ;
+    lws:usePolicy <#company-policy> ;
+    lws:target </company/handbook/> ;
+    lws:inheritable true .
+```
+
+### Appendix D: Reference Implementation
+
+[Link to reference implementation]
+
+### Appendix E: Test Suite
+
+[Description of conformance test suite]
+
+## Conclusion
+
+The proposed LWS Access Control Model provides a unified approach that:
+1. Maps cleanly to existing provider models
+2. Supports rich Solid-style access control
+3. Enables progressive enhancement
+4. Maintains security and privacy
+5. Provides clear migration paths
+
+This model balances the need for standardization with the reality of existing provider implementations, creating a foundation for interoperable personal data storage with sophisticated access control suitable for both human users and autonomous agents.

--- a/lws-access-control-summary.md
+++ b/lws-access-control-summary.md
@@ -1,0 +1,132 @@
+# Linked Web Storage Access Control - Summary
+
+## Overview
+
+This document summarizes the access control model proposed for the Linked Web Storage (LWS) specification, designed to provide a unified approach that can be adopted by major cloud storage providers while maintaining compatibility with existing Solid specifications.
+
+## Key Deliverables
+
+1. **Comprehensive Analysis Document** (`lws-access-control-policies.md`)
+   - Analysis of access control features across major providers:
+     - Google Drive (role-based permissions)
+     - Microsoft OneDrive (Graph API permissions)
+     - Dropbox (member-based permissions)
+     - AWS S3 (IAM policies)
+     - Solid WAC (mode-based permissions)
+     - Solid ACP (policy-based access control)
+   - Identification of common patterns and divergent approaches
+   - Proposed unified LWS access control model
+   - Implementation considerations and migration path
+
+2. **RDF Vocabulary** (`vocabs/lws-acl.ttl`)
+   - Complete OWL ontology for LWS access control
+   - Core classes: Authorization, Policy, Principal, Resource, PermissionMode
+   - Permission modes: Read, Write, Append, Delete, Control, Share
+   - Support for temporal access, conditions, delegation, and groups
+   - Provider capability negotiation vocabulary
+
+3. **N3 Rules** (`rules/lws-acl.n3`)
+   - Formal logic for access control evaluation
+   - Rules for direct grants, group access, inheritance, and policies
+   - Temporal validity and condition checking
+   - Audit trail generation
+   - Default deny semantics
+
+## Core Design Principles
+
+1. **Compatibility First**: Implementable as a facade over existing provider APIs
+2. **Semantic Clarity**: RDF/Linked Data for interoperability
+3. **Progressive Enhancement**: Basic features universal, advanced optional
+4. **Security by Default**: Fail closed, explicit grants required
+5. **Auditability**: Clear authorization paths
+
+## Key Features
+
+### Universal Features (All Providers Must Support)
+- Basic permission modes: Read, Write, Delete
+- User and group principals
+- Resource-level permissions
+- Basic inheritance
+
+### Advanced Features (Optional)
+- Append and Control modes
+- Conditional access (IP ranges, time periods)
+- Policy-based authorization
+- Delegated access (OAuth-style)
+- Verifiable Credentials integration
+- Fine-grained audit trails
+
+## Provider Mapping Example
+
+| LWS Mode | Google Drive | OneDrive | Dropbox | AWS S3 | WAC | ACP |
+|----------|--------------|----------|---------|---------|-----|-----|
+| Read | reader | read | viewer | s3:GetObject | acl:Read | acp:Read |
+| Write | writer | write | editor | s3:PutObject | acl:Write | acp:Write |
+| Control | owner | owner | owner | s3:PutBucketAcl | acl:Control | acp:Control |
+
+## Implementation Roadmap
+
+### Phase 1 (Months 1-3): Basic Compatibility
+- Core permission modes
+- User/group principals
+- Resource-level permissions
+
+### Phase 2 (Months 4-6): Enhanced Features
+- Append and Control modes
+- Inheritance
+- Time-based access
+
+### Phase 3 (Months 7-12): Advanced Capabilities
+- Conditional access
+- Policy-based authorization
+- Verifiable credentials
+
+## Next Steps
+
+1. **Provider Engagement**
+   - Present proposal to Google, Microsoft, Dropbox, AWS teams
+   - Gather feedback on implementation feasibility
+   - Identify provider-specific constraints
+
+2. **Reference Implementation**
+   - Develop adapter interfaces
+   - Create provider-specific adapters
+   - Build conformance test suite
+
+3. **Standards Process**
+   - Incorporate into LWS specification
+   - Coordinate with Solid community
+   - Engage with W3C working group
+
+## Benefits for Stakeholders
+
+### For Storage Providers
+- Standardized access control interface
+- Reduced integration complexity for applications
+- Enhanced interoperability
+
+### For Application Developers
+- Single API for multiple storage providers
+- Rich semantic access control
+- Support for advanced use cases
+
+### For End Users
+- Consistent permissions across providers
+- Better control over data access
+- Enhanced privacy and security
+
+### For the Agentic Web
+- Standardized way for AI agents to access user data
+- Fine-grained permission delegation
+- Audit trails for agent actions
+
+## Conclusion
+
+The proposed LWS access control model provides a pragmatic path forward that:
+- Unifies access control across major storage providers
+- Maintains compatibility with existing systems
+- Enables rich semantic access control features
+- Supports emerging use cases like agentic access
+- Provides clear migration paths for adoption
+
+This work positions LWS as the canonical standard for cloud storage access control, reducing fragmentation and enabling innovative applications while maintaining security and user control.

--- a/rules/lws-acl.n3
+++ b/rules/lws-acl.n3
@@ -1,0 +1,398 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+@prefix string: <http://www.w3.org/2000/10/swap/string#> .
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+@prefix time: <http://www.w3.org/2000/10/swap/time#> .
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+@prefix lws: <http://www.w3.org/ns/lws#> .
+@prefix : <http://www.w3.org/ns/lws/rules#> .
+
+# Linked Web Storage Access Control Evaluation Rules
+# These rules describe how LWS evaluates access control decisions
+
+#################################################################
+# Rule 1: Direct Authorization Grant
+# A request is allowed if there is a direct authorization that:
+# - Grants the requested mode to the principal
+# - Targets the requested resource
+# - Is currently valid (time-wise)
+# - Meets all conditions
+#################################################################
+
+{
+    ?request a lws:AccessRequest ;
+        lws:requestedBy ?principal ;
+        lws:requestsMode ?mode ;
+        lws:requestsResource ?resource ;
+        lws:requestTime ?time .
+    
+    ?auth a lws:Authorization ;
+        lws:grantedTo ?principal ;
+        lws:grants ?mode ;
+        lws:target ?resource .
+    
+    # Check temporal validity
+    ?auth :isTemporallyValid ?time .
+    
+    # Check conditions if any
+    ?auth :meetsAllConditions ?request .
+    
+} => {
+    ?request lws:decision lws:Allowed ;
+        lws:decidedBy ?auth ;
+        :reason "Direct authorization grant" .
+} .
+
+#################################################################
+# Rule 2: Group-based Authorization
+# A request is allowed if the principal is a member of a group
+# that has been granted access
+#################################################################
+
+{
+    ?request a lws:AccessRequest ;
+        lws:requestedBy ?principal ;
+        lws:requestsMode ?mode ;
+        lws:requestsResource ?resource ;
+        lws:requestTime ?time .
+    
+    ?principal lws:memberOf ?group .
+    
+    ?auth a lws:Authorization ;
+        lws:grantedTo ?group ;
+        lws:grants ?mode ;
+        lws:target ?resource .
+    
+    ?auth :isTemporallyValid ?time .
+    ?auth :meetsAllConditions ?request .
+    
+} => {
+    ?request lws:decision lws:Allowed ;
+        lws:decidedBy ?auth ;
+        :reason "Group membership authorization" .
+} .
+
+#################################################################
+# Rule 3: Inherited Authorization
+# A request is allowed if there is an authorization on a parent
+# resource that is marked as inheritable
+#################################################################
+
+{
+    ?request a lws:AccessRequest ;
+        lws:requestedBy ?principal ;
+        lws:requestsMode ?mode ;
+        lws:requestsResource ?resource ;
+        lws:requestTime ?time .
+    
+    ?resource lws:hasParent ?parent .
+    
+    ?auth a lws:Authorization ;
+        lws:grantedTo ?principal ;
+        lws:grants ?mode ;
+        lws:target ?parent ;
+        lws:inheritable true .
+    
+    ?auth :isTemporallyValid ?time .
+    ?auth :meetsAllConditions ?request .
+    
+} => {
+    ?request lws:decision lws:Allowed ;
+        lws:decidedBy ?auth ;
+        :reason "Inherited authorization from parent" .
+} .
+
+#################################################################
+# Rule 4: Authenticated Agent Authorization
+# Any authenticated agent gets access if authorized
+#################################################################
+
+{
+    ?request a lws:AccessRequest ;
+        lws:requestedBy ?principal ;
+        lws:requestsMode ?mode ;
+        lws:requestsResource ?resource ;
+        lws:requestTime ?time .
+    
+    ?principal a lws:User .  # Any authenticated user
+    
+    ?auth a lws:Authorization ;
+        lws:grantedTo lws:AuthenticatedAgent ;
+        lws:grants ?mode ;
+        lws:target ?resource .
+    
+    ?auth :isTemporallyValid ?time .
+    ?auth :meetsAllConditions ?request .
+    
+} => {
+    ?request lws:decision lws:Allowed ;
+        lws:decidedBy ?auth ;
+        :reason "Authenticated agent authorization" .
+} .
+
+#################################################################
+# Rule 5: Public Access
+# Anyone (including anonymous) gets access if authorized
+#################################################################
+
+{
+    ?request a lws:AccessRequest ;
+        lws:requestsMode ?mode ;
+        lws:requestsResource ?resource ;
+        lws:requestTime ?time .
+    
+    ?auth a lws:Authorization ;
+        lws:grantedTo lws:PublicAgent ;
+        lws:grants ?mode ;
+        lws:target ?resource .
+    
+    ?auth :isTemporallyValid ?time .
+    ?auth :meetsAllConditions ?request .
+    
+} => {
+    ?request lws:decision lws:Allowed ;
+        lws:decidedBy ?auth ;
+        :reason "Public access authorization" .
+} .
+
+#################################################################
+# Rule 6: Policy-based Authorization
+# A request is allowed if it satisfies a policy referenced by an auth
+#################################################################
+
+{
+    ?request a lws:AccessRequest ;
+        lws:requestedBy ?principal ;
+        lws:requestsMode ?mode ;
+        lws:requestsResource ?resource ;
+        lws:requestTime ?time .
+    
+    ?auth a lws:Authorization ;
+        lws:usePolicy ?policy ;
+        lws:target ?resource .
+    
+    ?policy a lws:Policy ;
+        lws:grants ?mode .
+    
+    # Check if principal matches policy requirements
+    ?principal :satisfiesPolicy ?policy .
+    
+    ?auth :isTemporallyValid ?time .
+    ?auth :meetsAllConditions ?request .
+    
+} => {
+    ?request lws:decision lws:Allowed ;
+        lws:decidedBy ?auth ;
+        :reason "Policy-based authorization" .
+} .
+
+#################################################################
+# Rule 7: Delegated Access
+# An application can access resources on behalf of a user
+#################################################################
+
+{
+    ?request a lws:AccessRequest ;
+        lws:requestedBy ?app ;
+        lws:requestsMode ?mode ;
+        lws:requestsResource ?resource ;
+        lws:requestTime ?time ;
+        lws:onBehalfOf ?user .
+    
+    ?app a lws:Application .
+    
+    ?auth a lws:Authorization ;
+        lws:grantedTo ?app ;
+        lws:grants ?mode ;
+        lws:target ?resource ;
+        lws:onBehalfOf ?user .
+    
+    # Check if requested scope matches granted scope
+    ?request lws:requestedScope ?reqScope .
+    ?auth lws:scope ?grantedScope .
+    ?reqScope :isSubsetOf ?grantedScope .
+    
+    ?auth :isTemporallyValid ?time .
+    ?auth :meetsAllConditions ?request .
+    
+} => {
+    ?request lws:decision lws:Allowed ;
+        lws:decidedBy ?auth ;
+        :reason "Delegated access authorization" .
+} .
+
+#################################################################
+# Helper Rules for Temporal Validity
+#################################################################
+
+# Authorization is temporally valid if current time is within bounds
+{
+    ?auth a lws:Authorization .
+    ?time a :CurrentTime .
+    
+    # Check validFrom if present
+    {
+        ?auth lws:validFrom ?from .
+        ?time :value ?timeValue .
+        ?from :value ?fromValue .
+        ?timeValue math:notLessThan ?fromValue .
+    } log:or {
+        ?auth log:notIncludes { ?auth lws:validFrom ?any } .
+    } .
+    
+    # Check validUntil if present
+    {
+        ?auth lws:validUntil ?until .
+        ?time :value ?timeValue .
+        ?until :value ?untilValue .
+        ?timeValue math:notGreaterThan ?untilValue .
+    } log:or {
+        ?auth log:notIncludes { ?auth lws:validUntil ?any } .
+    } .
+    
+} => {
+    ?auth :isTemporallyValid ?time .
+} .
+
+#################################################################
+# Helper Rules for Condition Checking
+#################################################################
+
+# Authorization meets all conditions if it has no conditions
+{
+    ?auth a lws:Authorization .
+    ?request a lws:AccessRequest .
+    
+    ?auth log:notIncludes { ?auth lws:condition ?any } .
+    
+} => {
+    ?auth :meetsAllConditions ?request .
+} .
+
+# Authorization meets all conditions if all conditions are satisfied
+{
+    ?auth a lws:Authorization ;
+        lws:condition ?condition .
+    ?request a lws:AccessRequest .
+    
+    # Check IP range condition
+    {
+        ?condition lws:ipRange ?range .
+        ?request lws:clientIP ?ip .
+        ?ip :inRange ?range .
+    } log:or {
+        ?condition log:notIncludes { ?condition lws:ipRange ?any } .
+    } .
+    
+    # Check time period condition
+    {
+        ?condition lws:validDuring ?period .
+        ?request lws:requestTime ?time .
+        ?time :during ?period .
+    } log:or {
+        ?condition log:notIncludes { ?condition lws:validDuring ?any } .
+    } .
+    
+    # Add more condition checks as needed
+    
+} => {
+    ?auth :meetsAllConditions ?request .
+} .
+
+#################################################################
+# Helper Rules for Policy Satisfaction
+#################################################################
+
+# Principal satisfies policy if it matches the principal class
+{
+    ?principal a ?class .
+    ?policy lws:principalClass ?class .
+} => {
+    ?principal :satisfiesPolicy ?policy .
+} .
+
+# Principal satisfies policy if it's in the required group
+{
+    ?principal lws:memberOf ?group .
+    ?policy lws:condition [ lws:memberOf ?group ] .
+} => {
+    ?principal :satisfiesPolicy ?policy .
+} .
+
+# Principal satisfies policy if email domain matches
+{
+    ?principal lws:email ?email .
+    ?policy lws:condition [ lws:emailDomain ?domain ] .
+    ?email string:endsWith ?domain .
+} => {
+    ?principal :satisfiesPolicy ?policy .
+} .
+
+#################################################################
+# Rule 8: Mode Inheritance
+# Write mode implies Append mode
+#################################################################
+
+{
+    ?auth lws:grants lws:Write .
+} => {
+    ?auth lws:grants lws:Append .
+} .
+
+#################################################################
+# Rule 9: Control Mode Super-permission
+# Control mode implies all other modes for administrative access
+#################################################################
+
+{
+    ?auth lws:grants lws:Control .
+} => {
+    ?auth lws:grants lws:Read ;
+        lws:grants lws:Write ;
+        lws:grants lws:Append ;
+        lws:grants lws:Delete ;
+        lws:grants lws:Share .
+} .
+
+#################################################################
+# Rule 10: Default Deny
+# If no allow decision has been made, the request is denied
+# This is implemented by the absence of an Allow decision
+#################################################################
+
+{
+    ?request a lws:AccessRequest .
+    
+    # No allow decision exists
+    ?request log:notIncludes { ?request lws:decision lws:Allowed } .
+    
+} => {
+    ?request lws:decision lws:Denied ;
+        :reason "No matching authorization found" .
+} .
+
+#################################################################
+# Audit Trail Generation
+#################################################################
+
+{
+    ?request a lws:AccessRequest ;
+        lws:requestedBy ?principal ;
+        lws:requestsMode ?mode ;
+        lws:requestsResource ?resource ;
+        lws:requestTime ?time ;
+        lws:decision ?decision .
+    
+    ?decision :decidedBy ?auth .
+    
+} => {
+    [ a lws:AuditEntry ;
+        lws:timestamp ?time ;
+        lws:principal ?principal ;
+        lws:action ?mode ;
+        lws:resource ?resource ;
+        lws:result ?decision ;
+        lws:authorization ?auth
+    ] .
+} .

--- a/rules/s3.n3
+++ b/rules/s3.n3
@@ -1,0 +1,523 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+@prefix string: <http://www.w3.org/2000/10/swap/string#> .
+@prefix list: <http://www.w3.org/2000/10/swap/list#> .
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+@prefix s3: <http://www.w3.org/ns/s3#> .
+@prefix : <http://www.w3.org/ns/s3/rules#> .
+
+# AWS S3 Access Control Evaluation Rules
+# These rules describe how AWS S3 evaluates access control decisions
+
+# Rule 1: A request is allowed if there is an Allow statement that matches
+# and no Deny statement that matches
+{
+    ?request a s3:Request ;
+        s3:madeBy ?principal ;
+        s3:requestsAction ?action ;
+        s3:targetsResource ?resource ;
+        s3:hasContext ?context .
+    
+    # Find an Allow statement that matches
+    ?statement a s3:Statement ;
+        s3:hasEffect s3:Allow ;
+        s3:hasPrincipal ?principal ;
+        s3:hasAction ?action ;
+        s3:hasResource ?resource .
+    
+    # Check conditions if present
+    ?statement s3:hasCondition ?condition .
+    ?condition :evaluatesTrue ?context .
+    
+    # No Deny statement matches
+    ( ?statement2 {
+        ?statement2 a s3:Statement ;
+            s3:hasEffect s3:Deny ;
+            s3:hasPrincipal ?principal ;
+            s3:hasAction ?action ;
+            s3:hasResource ?resource .
+    } ?denies ) log:collectAllIn _:x .
+    ?denies list:length 0 .
+} => {
+    ?request :isAllowed true .
+} .
+
+# Rule 2: A request is denied if there is any Deny statement that matches
+{
+    ?request a s3:Request ;
+        s3:madeBy ?principal ;
+        s3:requestsAction ?action ;
+        s3:targetsResource ?resource ;
+        s3:hasContext ?context .
+    
+    # Find a Deny statement that matches
+    ?statement a s3:Statement ;
+        s3:hasEffect s3:Deny ;
+        s3:hasPrincipal ?principal ;
+        s3:hasAction ?action ;
+        s3:hasResource ?resource .
+    
+    # Check conditions if present
+    ?statement s3:hasCondition ?condition .
+    ?condition :evaluatesTrue ?context .
+} => {
+    ?request :isDenied true .
+} .
+
+# Rule 3: Explicit Deny always overrides Allow
+{
+    ?request :isAllowed true ;
+        :isDenied true .
+} => {
+    ?request :finalDecision s3:Deny .
+} .
+
+# Rule 4: If only allowed (no deny), then allow
+{
+    ?request :isAllowed true .
+    # No deny exists
+    ( ?d { ?request :isDenied ?d } ?denials ) log:collectAllIn _:x .
+    ?denials list:length 0 .
+} => {
+    ?request :finalDecision s3:Allow .
+} .
+
+# Rule 5: Default deny - if no explicit allow, then deny
+{
+    ?request a s3:Request .
+    # No allow exists
+    ( ?a { ?request :isAllowed ?a } ?allows ) log:collectAllIn _:x .
+    ?allows list:length 0 .
+} => {
+    ?request :finalDecision s3:Deny .
+} .
+
+# Rule 6: Principal matching - wildcard principal
+{
+    ?statement s3:hasPrincipal "*" .
+    ?request s3:madeBy ?anyPrincipal .
+} => {
+    ?statement :matchesPrincipal ?anyPrincipal .
+} .
+
+# Rule 7: Principal matching - specific principal
+{
+    ?statement s3:hasPrincipal ?principal .
+    ?request s3:madeBy ?principal .
+    ?principal log:notEqualTo "*" .
+} => {
+    ?statement :matchesPrincipal ?principal .
+} .
+
+# Rule 8: Resource matching with wildcards
+{
+    ?statement s3:hasResource ?resourcePattern .
+    ?request s3:targetsResource ?resource .
+    ?resource s3:arn ?resourceArn .
+    ?resourcePattern string:matches ".*\\*.*" .
+    # Convert pattern to regex and match
+    ( ?resourcePattern "\\*" "(.*)" ) string:replace ?regex .
+    ?resourceArn string:matches ?regex .
+} => {
+    ?statement :matchesResource ?resource .
+} .
+
+# Rule 9: Exact resource matching
+{
+    ?statement s3:hasResource ?resource .
+    ?request s3:targetsResource ?resource .
+    ?resource s3:arn ?arn .
+    ?arn string:matches "^[^*]+$" .  # No wildcards
+} => {
+    ?statement :matchesResource ?resource .
+} .
+
+# Rule 10: Action matching with wildcards
+{
+    ?statement s3:hasAction ?actionPattern .
+    ?request s3:requestsAction ?action .
+    ?action s3:actionName ?actionName .
+    ?actionPattern string:matches ".*\\*" .
+    # s3:* matches all S3 actions
+    ( ?actionPattern "s3:\\*" "s3:.*" ) string:replace ?regex .
+    ?actionName string:matches ?regex .
+} => {
+    ?statement :matchesAction ?action .
+} .
+
+# Rule 11: Exact action matching
+{
+    ?statement s3:hasAction ?action .
+    ?request s3:requestsAction ?action .
+} => {
+    ?statement :matchesAction ?action .
+} .
+
+# Rule 12: String condition evaluation - StringEquals
+{
+    ?condition a s3:StringCondition ;
+        s3:conditionOperator "StringEquals" ;
+        s3:conditionKey ?key ;
+        s3:conditionValue ?expectedValue .
+    ?context ?key ?actualValue .
+    ?actualValue log:equalTo ?expectedValue .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 13: String condition evaluation - StringNotEquals
+{
+    ?condition a s3:StringCondition ;
+        s3:conditionOperator "StringNotEquals" ;
+        s3:conditionKey ?key ;
+        s3:conditionValue ?expectedValue .
+    ?context ?key ?actualValue .
+    ?actualValue log:notEqualTo ?expectedValue .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 14: String condition evaluation - StringLike
+{
+    ?condition a s3:StringCondition ;
+        s3:conditionOperator "StringLike" ;
+        s3:conditionKey ?key ;
+        s3:conditionValue ?pattern .
+    ?context ?key ?actualValue .
+    # Convert pattern to regex
+    ( ?pattern "\\*" "(.*)" ) string:replace ?regex .
+    ?actualValue string:matches ?regex .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 15: Boolean condition evaluation - Bool
+{
+    ?condition a s3:BooleanCondition ;
+        s3:conditionOperator "Bool" ;
+        s3:conditionKey ?key ;
+        s3:conditionValue ?expectedValue .
+    ?context ?key ?actualValue .
+    ?actualValue log:equalTo ?expectedValue .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 16: IP address condition evaluation - IpAddress
+{
+    ?condition a s3:IpAddressCondition ;
+        s3:conditionOperator "IpAddress" ;
+        s3:conditionKey ?key ;
+        s3:conditionValue ?cidr .
+    ?context ?key ?ipAddress .
+    # Check if IP is in CIDR range
+    ( ?ipAddress ?cidr ) :ipInCidr true .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 17: Numeric condition evaluation - NumericLessThan
+{
+    ?condition a s3:NumericCondition ;
+        s3:conditionOperator "NumericLessThan" ;
+        s3:conditionKey ?key ;
+        s3:conditionValue ?threshold .
+    ?context ?key ?actualValue .
+    ?actualValue math:lessThan ?threshold .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 18: Numeric condition evaluation - NumericGreaterThan
+{
+    ?condition a s3:NumericCondition ;
+        s3:conditionOperator "NumericGreaterThan" ;
+        s3:conditionKey ?key ;
+        s3:conditionValue ?threshold .
+    ?context ?key ?actualValue .
+    ?actualValue math:greaterThan ?threshold .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 19: Date condition evaluation - DateLessThan
+{
+    ?condition a s3:DateCondition ;
+        s3:conditionOperator "DateLessThan" ;
+        s3:conditionKey ?key ;
+        s3:conditionValue ?threshold .
+    ?context ?key ?actualValue .
+    # Compare timestamps
+    ?actualValue :isBefore ?threshold .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 20: Multiple conditions - all must be true (AND logic)
+{
+    ?statement s3:hasCondition ?condition1 ;
+        s3:hasCondition ?condition2 .
+    ?condition1 log:notEqualTo ?condition2 .
+    ?condition1 :evaluatesTrue ?context .
+    ?condition2 :evaluatesTrue ?context .
+} => {
+    ?statement :allConditionsTrue ?context .
+} .
+
+# Rule 21: Bucket policy evaluation
+{
+    ?bucket a s3:Bucket .
+    ?policy a s3:BucketPolicy ;
+        s3:attachedTo ?bucket ;
+        s3:hasStatement ?statement .
+    ?request s3:targetsResource ?resource .
+    ?resource :isInBucket ?bucket .
+    ?statement :matchesPrincipal ?principal ;
+        :matchesAction ?action ;
+        :matchesResource ?resource .
+} => {
+    ?policy :appliesTo ?request .
+} .
+
+# Rule 22: Identity-based policy evaluation
+{
+    ?principal a s3:Principal .
+    ?policy a s3:IdentityBasedPolicy ;
+        s3:attachedTo ?principal ;
+        s3:hasStatement ?statement .
+    ?request s3:madeBy ?principal .
+    ?statement :matchesAction ?action ;
+        :matchesResource ?resource .
+} => {
+    ?policy :appliesTo ?request .
+} .
+
+# Rule 23: ACL evaluation - grant matching
+{
+    ?acl a s3:ACL ;
+        s3:attachedTo ?resource ;
+        s3:hasGrant ?grant .
+    ?grant s3:grantee ?principal ;
+        s3:permission ?permission .
+    ?request s3:madeBy ?principal ;
+        s3:targetsResource ?resource ;
+        s3:requestsAction ?action .
+    ?permission :allowsAction ?action .
+} => {
+    ?acl :grants ?request .
+} .
+
+# Rule 24: Permission to action mapping for ACLs
+{
+    s3:READ :allowsAction s3:GetObject .
+    s3:WRITE :allowsAction s3:PutObject .
+    s3:READ_ACP :allowsAction s3:GetObjectAcl .
+    s3:WRITE_ACP :allowsAction s3:PutObjectAcl .
+    s3:FULL_CONTROL :allowsAction s3:GetObject ;
+        :allowsAction s3:PutObject ;
+        :allowsAction s3:DeleteObject ;
+        :allowsAction s3:GetObjectAcl ;
+        :allowsAction s3:PutObjectAcl .
+} .
+
+# Rule 25: Block Public Access enforcement
+{
+    ?bucket s3:hasBlockPublicAccess ?bpa .
+    ?bpa s3:blockPublicPolicy true .
+    ?policy a s3:BucketPolicy ;
+        s3:attachedTo ?bucket ;
+        s3:hasStatement ?statement .
+    ?statement s3:hasPrincipal "*" ;
+        s3:hasEffect s3:Allow .
+} => {
+    ?statement :isBlockedByBPA true .
+} .
+
+# Rule 26: Object ownership determines ACL applicability
+{
+    ?bucket s3:hasObjectOwnership s3:BucketOwnerEnforced .
+    ?object :isInBucket ?bucket .
+    ?acl s3:attachedTo ?object .
+} => {
+    ?acl :isDisabled true .
+} .
+
+# Rule 27: Cross-account access requires both policies
+{
+    ?request s3:madeBy ?principal ;
+        s3:targetsResource ?resource .
+    ?principal s3:accountId ?principalAccount .
+    ?resource s3:resourceAccount ?resourceAccount .
+    ?principalAccount log:notEqualTo ?resourceAccount .
+} => {
+    ?request :requiresCrossAccountPolicies true .
+} .
+
+# Rule 28: Service principal special handling
+{
+    ?principal a s3:ServicePrincipal .
+    ?request s3:madeBy ?principal .
+    ?context s3:principalIsAWSService true .
+} => {
+    ?request :bypassesNetworkRestrictions true .
+} .
+
+# Rule 29: MFA requirement check
+{
+    ?statement s3:hasCondition ?condition .
+    ?condition a s3:BooleanCondition ;
+        s3:conditionKey "aws:MultiFactorAuthPresent" ;
+        s3:conditionOperator "Bool" ;
+        s3:conditionValue true .
+    ?context s3:MultiFactorAuthPresent false .
+} => {
+    ?statement :requirementNotMet "MFA" .
+} .
+
+# Rule 30: Secure transport requirement
+{
+    ?statement s3:hasCondition ?condition .
+    ?condition a s3:BooleanCondition ;
+        s3:conditionKey "aws:SecureTransport" ;
+        s3:conditionOperator "Bool" ;
+        s3:conditionValue true .
+    ?context s3:isSecureTransport false .
+} => {
+    ?statement :requirementNotMet "SecureTransport" .
+} .
+
+# Rule 31: Tag-based access control
+{
+    ?statement s3:hasCondition ?condition .
+    ?condition a s3:StringCondition ;
+        s3:conditionKey ?tagKey ;
+        s3:conditionOperator "StringEquals" ;
+        s3:conditionValue ?expectedTagValue .
+    ?tagKey string:startsWith "s3:ExistingObjectTag/" .
+    ?resource s3:hasTag ?tag .
+    ?tag s3:tagKey ?actualKey ;
+        s3:tagValue ?actualValue .
+    ( ?tagKey "s3:ExistingObjectTag/" "" ) string:replace ?actualKey .
+    ?actualValue log:equalTo ?expectedTagValue .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 32: Request tag validation
+{
+    ?statement s3:hasCondition ?condition .
+    ?condition a s3:StringCondition ;
+        s3:conditionKey ?tagKey ;
+        s3:conditionValue ?expectedValue .
+    ?tagKey string:startsWith "s3:RequestObjectTag/" .
+    ?context s3:RequestObjectTag ?requestTag .
+    ?requestTag s3:tagKey ?actualKey ;
+        s3:tagValue ?actualValue .
+    ( ?tagKey "s3:RequestObjectTag/" "" ) string:replace ?actualKey .
+    ?actualValue log:equalTo ?expectedValue .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 33: Version-specific access
+{
+    ?statement s3:hasCondition ?condition .
+    ?condition a s3:StringCondition ;
+        s3:conditionKey "s3:VersionId" ;
+        s3:conditionValue ?requiredVersion .
+    ?context s3:VersionId ?actualVersion .
+    ?actualVersion log:equalTo ?requiredVersion .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 34: Prefix-based access for ListBucket
+{
+    ?statement s3:hasAction s3:ListBucket ;
+        s3:hasCondition ?condition .
+    ?condition a s3:StringCondition ;
+        s3:conditionKey "s3:prefix" ;
+        s3:conditionValue ?allowedPrefix .
+    ?context s3:prefix ?requestedPrefix .
+    ?requestedPrefix string:startsWith ?allowedPrefix .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 35: Storage class restriction
+{
+    ?statement s3:hasAction s3:PutObject ;
+        s3:hasCondition ?condition .
+    ?condition a s3:StringCondition ;
+        s3:conditionKey "s3:x-amz-storage-class" ;
+        s3:conditionValue ?allowedClass .
+    ?context s3:x-amz-storage-class ?requestedClass .
+    ?requestedClass log:equalTo ?allowedClass .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 36: Server-side encryption requirement
+{
+    ?statement s3:hasAction s3:PutObject ;
+        s3:hasCondition ?condition .
+    ?condition a s3:StringCondition ;
+        s3:conditionKey "s3:x-amz-server-side-encryption" ;
+        s3:conditionOperator "StringEquals" ;
+        s3:conditionValue ?requiredEncryption .
+    ?context s3:x-amz-server-side-encryption ?actualEncryption .
+    ?actualEncryption log:equalTo ?requiredEncryption .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 37: Copy source restriction
+{
+    ?statement s3:hasAction s3:PutObject ;
+        s3:hasCondition ?condition .
+    ?condition a s3:StringCondition ;
+        s3:conditionKey "s3:x-amz-copy-source" ;
+        s3:conditionValue ?allowedSource .
+    ?context s3:x-amz-copy-source ?actualSource .
+    ?actualSource string:matches ?allowedSource .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 38: TLS version enforcement
+{
+    ?statement s3:hasCondition ?condition .
+    ?condition a s3:NumericCondition ;
+        s3:conditionKey "s3:TlsVersion" ;
+        s3:conditionOperator "NumericGreaterThanEquals" ;
+        s3:conditionValue ?minVersion .
+    ?context s3:TlsVersion ?actualVersion .
+    ?actualVersion math:notLessThan ?minVersion .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 39: Organization-based access control
+{
+    ?statement s3:hasCondition ?condition .
+    ?condition a s3:StringCondition ;
+        s3:conditionKey "aws:PrincipalOrgID" ;
+        s3:conditionValue ?allowedOrgId .
+    ?context s3:principalOrgId ?actualOrgId .
+    ?actualOrgId log:equalTo ?allowedOrgId .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .
+
+# Rule 40: VPC endpoint restriction
+{
+    ?statement s3:hasCondition ?condition .
+    ?condition a s3:StringCondition ;
+        s3:conditionKey "aws:SourceVpce" ;
+        s3:conditionValue ?allowedVpce .
+    ?context s3:sourceVpce ?actualVpce .
+    ?actualVpce log:equalTo ?allowedVpce .
+} => {
+    ?condition :evaluatesTrue ?context .
+} .

--- a/vocabs/lws-acl.ttl
+++ b/vocabs/lws-acl.ttl
@@ -1,0 +1,371 @@
+@prefix lws: <http://www.w3.org/ns/lws#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+# Linked Web Storage Access Control Vocabulary
+# This vocabulary defines the access control model for the Linked Web Storage specification
+
+lws: a owl:Ontology ;
+    rdfs:label "Linked Web Storage Access Control Vocabulary"@en ;
+    rdfs:comment "A vocabulary for describing access control in the Linked Web Storage specification, designed to be compatible with major cloud storage providers while supporting rich semantic access control"@en ;
+    dc:created "2024-01-15"^^xsd:date ;
+    dc:creator "W3C Linked Web Storage Working Group" ;
+    vann:preferredNamespacePrefix "lws" ;
+    vann:preferredNamespaceUri "http://www.w3.org/ns/lws#" .
+
+#################################################################
+# Core Classes
+#################################################################
+
+lws:Authorization a rdfs:Class, owl:Class ;
+    rdfs:label "Authorization"@en ;
+    rdfs:comment "A grant of access to a resource, connecting principals to resources with specific permission modes"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Policy a rdfs:Class, owl:Class ;
+    rdfs:label "Policy"@en ;
+    rdfs:comment "A reusable access control policy that can be applied to multiple resources"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Principal a rdfs:Class, owl:Class ;
+    rdfs:label "Principal"@en ;
+    rdfs:comment "An entity that can be granted access to resources (users, groups, applications, etc.)"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Resource a rdfs:Class, owl:Class ;
+    rdfs:label "Resource"@en ;
+    rdfs:comment "A resource that can be accessed (files, folders, containers, etc.)"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:PermissionMode a rdfs:Class, owl:Class ;
+    rdfs:label "Permission Mode"@en ;
+    rdfs:comment "A type of access that can be granted to a resource"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Condition a rdfs:Class, owl:Class ;
+    rdfs:label "Condition"@en ;
+    rdfs:comment "A condition that must be met for an authorization to be valid"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:AuditEntry a rdfs:Class, owl:Class ;
+    rdfs:label "Audit Entry"@en ;
+    rdfs:comment "A record of an access attempt or authorization change"@en ;
+    rdfs:isDefinedBy lws: .
+
+#################################################################
+# Principal Subclasses
+#################################################################
+
+lws:User a rdfs:Class, owl:Class ;
+    rdfs:subClassOf lws:Principal ;
+    rdfs:label "User"@en ;
+    rdfs:comment "An individual user principal"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Group a rdfs:Class, owl:Class ;
+    rdfs:subClassOf lws:Principal ;
+    rdfs:label "Group"@en ;
+    rdfs:comment "A group of principals"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Application a rdfs:Class, owl:Class ;
+    rdfs:subClassOf lws:Principal ;
+    rdfs:label "Application"@en ;
+    rdfs:comment "An application or service principal"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:AuthenticatedAgent a rdfs:Class, owl:Class ;
+    rdfs:subClassOf lws:Principal ;
+    rdfs:label "Authenticated Agent"@en ;
+    rdfs:comment "Any authenticated principal (not anonymous)"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:PublicAgent a rdfs:Class, owl:Class ;
+    rdfs:subClassOf lws:Principal ;
+    rdfs:label "Public Agent"@en ;
+    rdfs:comment "Any agent, including anonymous/unauthenticated"@en ;
+    rdfs:isDefinedBy lws: .
+
+#################################################################
+# Permission Mode Instances
+#################################################################
+
+lws:Read a lws:PermissionMode ;
+    rdfs:label "Read"@en ;
+    rdfs:comment "Permission to read/view resource content"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Write a lws:PermissionMode ;
+    rdfs:label "Write"@en ;
+    rdfs:comment "Permission to modify resource content"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Append a lws:PermissionMode ;
+    rdfs:subClassOf lws:Write ;
+    rdfs:label "Append"@en ;
+    rdfs:comment "Permission to add to resource content without modifying existing content"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Delete a lws:PermissionMode ;
+    rdfs:label "Delete"@en ;
+    rdfs:comment "Permission to remove resources"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Control a lws:PermissionMode ;
+    rdfs:label "Control"@en ;
+    rdfs:comment "Permission to modify access control settings"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Share a lws:PermissionMode ;
+    rdfs:label "Share"@en ;
+    rdfs:comment "Permission to share resources with others"@en ;
+    rdfs:isDefinedBy lws: .
+
+#################################################################
+# Properties
+#################################################################
+
+# Authorization Properties
+lws:grantedTo a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "granted to"@en ;
+    rdfs:comment "The principal to whom access is granted"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range lws:Principal ;
+    rdfs:isDefinedBy lws: .
+
+lws:grants a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "grants"@en ;
+    rdfs:comment "The permission mode(s) granted by this authorization"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range lws:PermissionMode ;
+    rdfs:isDefinedBy lws: .
+
+lws:target a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "target"@en ;
+    rdfs:comment "The resource to which access is granted"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range lws:Resource ;
+    rdfs:isDefinedBy lws: .
+
+lws:usePolicy a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "use policy"@en ;
+    rdfs:comment "References a reusable policy for this authorization"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range lws:Policy ;
+    rdfs:isDefinedBy lws: .
+
+lws:inheritsFrom a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "inherits from"@en ;
+    rdfs:comment "Indicates that this authorization inherits from another"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range lws:Authorization ;
+    rdfs:isDefinedBy lws: .
+
+lws:inheritable a rdf:Property, owl:DatatypeProperty ;
+    rdfs:label "inheritable"@en ;
+    rdfs:comment "Whether this authorization can be inherited by child resources"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range xsd:boolean ;
+    rdfs:isDefinedBy lws: .
+
+# Temporal Properties
+lws:validFrom a rdf:Property, owl:DatatypeProperty ;
+    rdfs:label "valid from"@en ;
+    rdfs:comment "The date/time from which this authorization is valid"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range xsd:dateTime ;
+    rdfs:isDefinedBy lws: .
+
+lws:validUntil a rdf:Property, owl:DatatypeProperty ;
+    rdfs:label "valid until"@en ;
+    rdfs:comment "The date/time until which this authorization is valid"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range xsd:dateTime ;
+    rdfs:isDefinedBy lws: .
+
+# Condition Properties
+lws:condition a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "condition"@en ;
+    rdfs:comment "Additional conditions that must be met for the authorization to be valid"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range lws:Condition ;
+    rdfs:isDefinedBy lws: .
+
+lws:ipRange a rdf:Property, owl:DatatypeProperty ;
+    rdfs:label "IP range"@en ;
+    rdfs:comment "IP address range from which access is allowed"@en ;
+    rdfs:domain lws:Condition ;
+    rdfs:range xsd:string ;
+    rdfs:isDefinedBy lws: .
+
+lws:validDuring a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "valid during"@en ;
+    rdfs:comment "Time period during which access is allowed"@en ;
+    rdfs:domain lws:Condition ;
+    rdfs:isDefinedBy lws: .
+
+# Delegation Properties
+lws:onBehalfOf a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "on behalf of"@en ;
+    rdfs:comment "The principal on whose behalf access is being granted"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range lws:Principal ;
+    rdfs:isDefinedBy lws: .
+
+lws:scope a rdf:Property, owl:DatatypeProperty ;
+    rdfs:label "scope"@en ;
+    rdfs:comment "OAuth-style scope string for delegated access"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range xsd:string ;
+    rdfs:isDefinedBy lws: .
+
+# Group Properties
+lws:memberOf a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "member of"@en ;
+    rdfs:comment "Indicates group membership"@en ;
+    rdfs:domain lws:Principal ;
+    rdfs:range lws:Group ;
+    rdfs:isDefinedBy lws: .
+
+lws:hasMember a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "has member"@en ;
+    rdfs:comment "Indicates that a group has a member"@en ;
+    rdfs:domain lws:Group ;
+    rdfs:range lws:Principal ;
+    owl:inverseOf lws:memberOf ;
+    rdfs:isDefinedBy lws: .
+
+# Policy Properties
+lws:principalClass a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "principal class"@en ;
+    rdfs:comment "Defines the class of principals to which a policy applies"@en ;
+    rdfs:domain lws:Policy ;
+    rdfs:range rdfs:Class ;
+    rdfs:isDefinedBy lws: .
+
+lws:emailDomain a rdf:Property, owl:DatatypeProperty ;
+    rdfs:label "email domain"@en ;
+    rdfs:comment "Email domain requirement for principals"@en ;
+    rdfs:domain lws:Condition ;
+    rdfs:range xsd:string ;
+    rdfs:isDefinedBy lws: .
+
+# Audit Properties
+lws:timestamp a rdf:Property, owl:DatatypeProperty ;
+    rdfs:label "timestamp"@en ;
+    rdfs:comment "The time of an audit event"@en ;
+    rdfs:domain lws:AuditEntry ;
+    rdfs:range xsd:dateTime ;
+    rdfs:isDefinedBy lws: .
+
+lws:action a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "action"@en ;
+    rdfs:comment "The action attempted or performed"@en ;
+    rdfs:domain lws:AuditEntry ;
+    rdfs:range lws:PermissionMode ;
+    rdfs:isDefinedBy lws: .
+
+lws:result a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "result"@en ;
+    rdfs:comment "The result of an access attempt"@en ;
+    rdfs:domain lws:AuditEntry ;
+    rdfs:isDefinedBy lws: .
+
+lws:principal a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "principal"@en ;
+    rdfs:comment "The principal involved in an audit event"@en ;
+    rdfs:domain lws:AuditEntry ;
+    rdfs:range lws:Principal ;
+    rdfs:isDefinedBy lws: .
+
+lws:resource a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "resource"@en ;
+    rdfs:comment "The resource involved in an audit event"@en ;
+    rdfs:domain lws:AuditEntry ;
+    rdfs:range lws:Resource ;
+    rdfs:isDefinedBy lws: .
+
+lws:authorization a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "authorization"@en ;
+    rdfs:comment "The authorization used for access"@en ;
+    rdfs:domain lws:AuditEntry ;
+    rdfs:range lws:Authorization ;
+    rdfs:isDefinedBy lws: .
+
+# Provider Capability Properties
+lws:StorageProvider a rdfs:Class, owl:Class ;
+    rdfs:label "Storage Provider"@en ;
+    rdfs:comment "A storage provider that implements LWS"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:supportsMode a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "supports mode"@en ;
+    rdfs:comment "Permission modes supported by a provider"@en ;
+    rdfs:domain lws:StorageProvider ;
+    rdfs:range lws:PermissionMode ;
+    rdfs:isDefinedBy lws: .
+
+lws:supportsFeature a rdf:Property, owl:ObjectProperty ;
+    rdfs:label "supports feature"@en ;
+    rdfs:comment "Advanced features supported by a provider"@en ;
+    rdfs:domain lws:StorageProvider ;
+    rdfs:isDefinedBy lws: .
+
+lws:maxPrincipalsPerResource a rdf:Property, owl:DatatypeProperty ;
+    rdfs:label "max principals per resource"@en ;
+    rdfs:comment "Maximum number of principals that can be granted access to a single resource"@en ;
+    rdfs:domain lws:StorageProvider ;
+    rdfs:range xsd:integer ;
+    rdfs:isDefinedBy lws: .
+
+lws:supportsInheritance a rdf:Property, owl:DatatypeProperty ;
+    rdfs:label "supports inheritance"@en ;
+    rdfs:comment "Whether the provider supports permission inheritance"@en ;
+    rdfs:domain lws:StorageProvider ;
+    rdfs:range xsd:boolean ;
+    rdfs:isDefinedBy lws: .
+
+# Access Result Values
+lws:Allowed a owl:Thing ;
+    rdfs:label "Allowed"@en ;
+    rdfs:comment "Access was allowed"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:Denied a owl:Thing ;
+    rdfs:label "Denied"@en ;
+    rdfs:comment "Access was denied"@en ;
+    rdfs:isDefinedBy lws: .
+
+# Additional Properties
+lws:note a rdf:Property, owl:DatatypeProperty ;
+    rdfs:label "note"@en ;
+    rdfs:comment "Human-readable note about an authorization"@en ;
+    rdfs:domain lws:Authorization ;
+    rdfs:range xsd:string ;
+    rdfs:isDefinedBy lws: .
+
+# Feature Instances
+lws:ConditionalAccess a owl:Thing ;
+    rdfs:label "Conditional Access"@en ;
+    rdfs:comment "Support for condition-based access control"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:GroupPrincipals a owl:Thing ;
+    rdfs:label "Group Principals"@en ;
+    rdfs:comment "Support for group-based access control"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:TemporalAccess a owl:Thing ;
+    rdfs:label "Temporal Access"@en ;
+    rdfs:comment "Support for time-based access control"@en ;
+    rdfs:isDefinedBy lws: .
+
+lws:DelegatedAccess a owl:Thing ;
+    rdfs:label "Delegated Access"@en ;
+    rdfs:comment "Support for delegated/on-behalf-of access"@en ;
+    rdfs:isDefinedBy lws: .

--- a/vocabs/s3.ttl
+++ b/vocabs/s3.ttl
@@ -1,3 +1,567 @@
-# https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_rcps_syntax.html
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix s3: <http://www.w3.org/ns/s3#> .
+@prefix iam: <http://www.w3.org/ns/iam#> .
 
-@prefix s3: <https://www.w3.org/ns/auth/s3#> .
+# AWS S3 Access Control Vocabulary
+# This vocabulary describes the concepts in the AWS S3 permission system
+
+s3: a owl:Ontology ;
+    rdfs:label "AWS S3 Access Control Vocabulary"@en ;
+    rdfs:comment "A vocabulary for describing AWS S3 access control concepts including policies, principals, actions, resources, and conditions"@en .
+
+# Core Classes
+
+s3:Policy a owl:Class ;
+    rdfs:label "Policy"@en ;
+    rdfs:comment "A JSON policy document that defines permissions"@en .
+
+s3:BucketPolicy a owl:Class ;
+    rdfs:subClassOf s3:Policy ;
+    rdfs:label "Bucket Policy"@en ;
+    rdfs:comment "A resource-based policy attached to an S3 bucket"@en .
+
+s3:IdentityBasedPolicy a owl:Class ;
+    rdfs:subClassOf s3:Policy ;
+    rdfs:label "Identity-Based Policy"@en ;
+    rdfs:comment "A policy attached to IAM users, groups, or roles"@en .
+
+s3:AccessPointPolicy a owl:Class ;
+    rdfs:subClassOf s3:Policy ;
+    rdfs:label "Access Point Policy"@en ;
+    rdfs:comment "A policy attached to an S3 Access Point"@en .
+
+s3:ACL a owl:Class ;
+    rdfs:label "Access Control List"@en ;
+    rdfs:comment "A list of grants identifying grantees and permissions"@en .
+
+s3:Statement a owl:Class ;
+    rdfs:label "Policy Statement"@en ;
+    rdfs:comment "A single permission rule within a policy"@en .
+
+s3:Principal a owl:Class ;
+    rdfs:label "Principal"@en ;
+    rdfs:comment "An entity that can make requests to AWS"@en .
+
+s3:AWSAccountPrincipal a owl:Class ;
+    rdfs:subClassOf s3:Principal ;
+    rdfs:label "AWS Account Principal"@en ;
+    rdfs:comment "An AWS account that can make requests"@en .
+
+s3:IAMUserPrincipal a owl:Class ;
+    rdfs:subClassOf s3:Principal ;
+    rdfs:label "IAM User Principal"@en ;
+    rdfs:comment "An IAM user that can make requests"@en .
+
+s3:IAMRolePrincipal a owl:Class ;
+    rdfs:subClassOf s3:Principal ;
+    rdfs:label "IAM Role Principal"@en ;
+    rdfs:comment "An IAM role that can make requests"@en .
+
+s3:FederatedUserPrincipal a owl:Class ;
+    rdfs:subClassOf s3:Principal ;
+    rdfs:label "Federated User Principal"@en ;
+    rdfs:comment "A federated user that can make requests"@en .
+
+s3:ServicePrincipal a owl:Class ;
+    rdfs:subClassOf s3:Principal ;
+    rdfs:label "Service Principal"@en ;
+    rdfs:comment "An AWS service that can make requests"@en .
+
+s3:AnonymousPrincipal a owl:Class ;
+    rdfs:subClassOf s3:Principal ;
+    rdfs:label "Anonymous Principal"@en ;
+    rdfs:comment "Unauthenticated users"@en .
+
+s3:Action a owl:Class ;
+    rdfs:label "Action"@en ;
+    rdfs:comment "An operation that can be performed on AWS resources"@en .
+
+s3:BucketAction a owl:Class ;
+    rdfs:subClassOf s3:Action ;
+    rdfs:label "Bucket Action"@en ;
+    rdfs:comment "An action that operates on S3 buckets"@en .
+
+s3:ObjectAction a owl:Class ;
+    rdfs:subClassOf s3:Action ;
+    rdfs:label "Object Action"@en ;
+    rdfs:comment "An action that operates on S3 objects"@en .
+
+s3:Resource a owl:Class ;
+    rdfs:label "Resource"@en ;
+    rdfs:comment "An AWS resource that can be accessed"@en .
+
+s3:Bucket a owl:Class ;
+    rdfs:subClassOf s3:Resource ;
+    rdfs:label "S3 Bucket"@en ;
+    rdfs:comment "An S3 bucket resource"@en .
+
+s3:Object a owl:Class ;
+    rdfs:subClassOf s3:Resource ;
+    rdfs:label "S3 Object"@en ;
+    rdfs:comment "An S3 object resource"@en .
+
+s3:AccessPoint a owl:Class ;
+    rdfs:subClassOf s3:Resource ;
+    rdfs:label "S3 Access Point"@en ;
+    rdfs:comment "An S3 Access Point resource"@en .
+
+s3:Condition a owl:Class ;
+    rdfs:label "Condition"@en ;
+    rdfs:comment "A condition that must be met for a statement to apply"@en .
+
+s3:StringCondition a owl:Class ;
+    rdfs:subClassOf s3:Condition ;
+    rdfs:label "String Condition"@en ;
+    rdfs:comment "A condition that compares string values"@en .
+
+s3:NumericCondition a owl:Class ;
+    rdfs:subClassOf s3:Condition ;
+    rdfs:label "Numeric Condition"@en ;
+    rdfs:comment "A condition that compares numeric values"@en .
+
+s3:DateCondition a owl:Class ;
+    rdfs:subClassOf s3:Condition ;
+    rdfs:label "Date Condition"@en ;
+    rdfs:comment "A condition that compares date/time values"@en .
+
+s3:BooleanCondition a owl:Class ;
+    rdfs:subClassOf s3:Condition ;
+    rdfs:label "Boolean Condition"@en ;
+    rdfs:comment "A condition that compares boolean values"@en .
+
+s3:IpAddressCondition a owl:Class ;
+    rdfs:subClassOf s3:Condition ;
+    rdfs:label "IP Address Condition"@en ;
+    rdfs:comment "A condition that compares IP addresses"@en .
+
+s3:ArnCondition a owl:Class ;
+    rdfs:subClassOf s3:Condition ;
+    rdfs:label "ARN Condition"@en ;
+    rdfs:comment "A condition that compares ARNs"@en .
+
+s3:Effect a owl:Class ;
+    rdfs:label "Effect"@en ;
+    rdfs:comment "The effect of a policy statement"@en .
+
+s3:Request a owl:Class ;
+    rdfs:label "Request"@en ;
+    rdfs:comment "A request to perform an action on a resource"@en .
+
+s3:RequestContext a owl:Class ;
+    rdfs:label "Request Context"@en ;
+    rdfs:comment "The context information associated with a request"@en .
+
+# Properties
+
+s3:hasStatement a owl:ObjectProperty ;
+    rdfs:domain s3:Policy ;
+    rdfs:range s3:Statement ;
+    rdfs:label "has statement"@en ;
+    rdfs:comment "Links a policy to its statements"@en .
+
+s3:hasPrincipal a owl:ObjectProperty ;
+    rdfs:domain s3:Statement ;
+    rdfs:range s3:Principal ;
+    rdfs:label "has principal"@en ;
+    rdfs:comment "Specifies the principal(s) for a statement"@en .
+
+s3:hasAction a owl:ObjectProperty ;
+    rdfs:domain s3:Statement ;
+    rdfs:range s3:Action ;
+    rdfs:label "has action"@en ;
+    rdfs:comment "Specifies the action(s) for a statement"@en .
+
+s3:hasResource a owl:ObjectProperty ;
+    rdfs:domain s3:Statement ;
+    rdfs:range s3:Resource ;
+    rdfs:label "has resource"@en ;
+    rdfs:comment "Specifies the resource(s) for a statement"@en .
+
+s3:hasCondition a owl:ObjectProperty ;
+    rdfs:domain s3:Statement ;
+    rdfs:range s3:Condition ;
+    rdfs:label "has condition"@en ;
+    rdfs:comment "Specifies condition(s) for a statement"@en .
+
+s3:hasEffect a owl:ObjectProperty ;
+    rdfs:domain s3:Statement ;
+    rdfs:range s3:Effect ;
+    rdfs:label "has effect"@en ;
+    rdfs:comment "Specifies the effect (Allow or Deny) of a statement"@en .
+
+s3:attachedTo a owl:ObjectProperty ;
+    rdfs:domain s3:Policy ;
+    rdfs:range s3:Resource ;
+    rdfs:label "attached to"@en ;
+    rdfs:comment "Specifies what resource a policy is attached to"@en .
+
+s3:madeBy a owl:ObjectProperty ;
+    rdfs:domain s3:Request ;
+    rdfs:range s3:Principal ;
+    rdfs:label "made by"@en ;
+    rdfs:comment "Specifies who made the request"@en .
+
+s3:requestsAction a owl:ObjectProperty ;
+    rdfs:domain s3:Request ;
+    rdfs:range s3:Action ;
+    rdfs:label "requests action"@en ;
+    rdfs:comment "Specifies what action is being requested"@en .
+
+s3:targetsResource a owl:ObjectProperty ;
+    rdfs:domain s3:Request ;
+    rdfs:range s3:Resource ;
+    rdfs:label "targets resource"@en ;
+    rdfs:comment "Specifies what resource is being accessed"@en .
+
+s3:hasContext a owl:ObjectProperty ;
+    rdfs:domain s3:Request ;
+    rdfs:range s3:RequestContext ;
+    rdfs:label "has context"@en ;
+    rdfs:comment "Links a request to its context information"@en .
+
+s3:conditionKey a owl:DatatypeProperty ;
+    rdfs:domain s3:Condition ;
+    rdfs:range xsd:string ;
+    rdfs:label "condition key"@en ;
+    rdfs:comment "The key being evaluated in a condition"@en .
+
+s3:conditionOperator a owl:DatatypeProperty ;
+    rdfs:domain s3:Condition ;
+    rdfs:range xsd:string ;
+    rdfs:label "condition operator"@en ;
+    rdfs:comment "The comparison operator for a condition"@en .
+
+s3:conditionValue a owl:DatatypeProperty ;
+    rdfs:domain s3:Condition ;
+    rdfs:range rdfs:Literal ;
+    rdfs:label "condition value"@en ;
+    rdfs:comment "The value to compare against in a condition"@en .
+
+s3:arn a owl:DatatypeProperty ;
+    rdfs:domain s3:Resource ;
+    rdfs:range xsd:string ;
+    rdfs:label "ARN"@en ;
+    rdfs:comment "Amazon Resource Name"@en .
+
+s3:principalId a owl:DatatypeProperty ;
+    rdfs:domain s3:Principal ;
+    rdfs:range xsd:string ;
+    rdfs:label "principal ID"@en ;
+    rdfs:comment "The unique identifier for a principal"@en .
+
+s3:accountId a owl:DatatypeProperty ;
+    rdfs:domain s3:AWSAccountPrincipal ;
+    rdfs:range xsd:string ;
+    rdfs:label "account ID"@en ;
+    rdfs:comment "AWS account identifier"@en .
+
+s3:actionName a owl:DatatypeProperty ;
+    rdfs:domain s3:Action ;
+    rdfs:range xsd:string ;
+    rdfs:label "action name"@en ;
+    rdfs:comment "The name of the action (e.g., s3:GetObject)"@en .
+
+s3:statementId a owl:DatatypeProperty ;
+    rdfs:domain s3:Statement ;
+    rdfs:range xsd:string ;
+    rdfs:label "statement ID"@en ;
+    rdfs:comment "Optional identifier for a statement"@en .
+
+s3:version a owl:DatatypeProperty ;
+    rdfs:domain s3:Policy ;
+    rdfs:range xsd:string ;
+    rdfs:label "version"@en ;
+    rdfs:comment "Policy language version"@en .
+
+# Effect Individuals
+s3:Allow a s3:Effect ;
+    rdfs:label "Allow"@en ;
+    rdfs:comment "Grants the specified permissions"@en .
+
+s3:Deny a s3:Effect ;
+    rdfs:label "Deny"@en ;
+    rdfs:comment "Explicitly denies the specified permissions"@en .
+
+# Common Actions
+s3:GetObject a s3:ObjectAction ;
+    s3:actionName "s3:GetObject" ;
+    rdfs:label "Get Object"@en ;
+    rdfs:comment "Permission to retrieve objects from S3"@en .
+
+s3:PutObject a s3:ObjectAction ;
+    s3:actionName "s3:PutObject" ;
+    rdfs:label "Put Object"@en ;
+    rdfs:comment "Permission to upload objects to S3"@en .
+
+s3:DeleteObject a s3:ObjectAction ;
+    s3:actionName "s3:DeleteObject" ;
+    rdfs:label "Delete Object"@en ;
+    rdfs:comment "Permission to delete objects from S3"@en .
+
+s3:ListBucket a s3:BucketAction ;
+    s3:actionName "s3:ListBucket" ;
+    rdfs:label "List Bucket"@en ;
+    rdfs:comment "Permission to list objects in a bucket"@en .
+
+s3:CreateBucket a s3:BucketAction ;
+    s3:actionName "s3:CreateBucket" ;
+    rdfs:label "Create Bucket"@en ;
+    rdfs:comment "Permission to create new buckets"@en .
+
+s3:DeleteBucket a s3:BucketAction ;
+    s3:actionName "s3:DeleteBucket" ;
+    rdfs:label "Delete Bucket"@en ;
+    rdfs:comment "Permission to delete buckets"@en .
+
+# Common Condition Keys
+s3:SourceIp a owl:Class ;
+    rdfs:subClassOf s3:IpAddressCondition ;
+    rdfs:label "Source IP Condition"@en ;
+    rdfs:comment "Condition based on request source IP"@en .
+
+s3:SecureTransport a owl:Class ;
+    rdfs:subClassOf s3:BooleanCondition ;
+    rdfs:label "Secure Transport Condition"@en ;
+    rdfs:comment "Condition requiring HTTPS/TLS"@en .
+
+s3:RequestTime a owl:Class ;
+    rdfs:subClassOf s3:DateCondition ;
+    rdfs:label "Request Time Condition"@en ;
+    rdfs:comment "Condition based on request timestamp"@en .
+
+# Access Control List Properties
+s3:hasGrant a owl:ObjectProperty ;
+    rdfs:domain s3:ACL ;
+    rdfs:range s3:Grant ;
+    rdfs:label "has grant"@en ;
+    rdfs:comment "Links an ACL to its grants"@en .
+
+s3:Grant a owl:Class ;
+    rdfs:label "Grant"@en ;
+    rdfs:comment "A permission grant in an ACL"@en .
+
+s3:grantee a owl:ObjectProperty ;
+    rdfs:domain s3:Grant ;
+    rdfs:range s3:Principal ;
+    rdfs:label "grantee"@en ;
+    rdfs:comment "The recipient of the grant"@en .
+
+s3:permission a owl:ObjectProperty ;
+    rdfs:domain s3:Grant ;
+    rdfs:range s3:Permission ;
+    rdfs:label "permission"@en ;
+    rdfs:comment "The permission being granted"@en .
+
+s3:Permission a owl:Class ;
+    rdfs:label "Permission"@en ;
+    rdfs:comment "A permission that can be granted via ACL"@en .
+
+# ACL Permissions
+s3:READ a s3:Permission ;
+    rdfs:label "READ"@en ;
+    rdfs:comment "Permission to read object data"@en .
+
+s3:WRITE a s3:Permission ;
+    rdfs:label "WRITE"@en ;
+    rdfs:comment "Permission to write objects"@en .
+
+s3:READ_ACP a s3:Permission ;
+    rdfs:label "READ_ACP"@en ;
+    rdfs:comment "Permission to read ACL"@en .
+
+s3:WRITE_ACP a s3:Permission ;
+    rdfs:label "WRITE_ACP"@en ;
+    rdfs:comment "Permission to write ACL"@en .
+
+s3:FULL_CONTROL a s3:Permission ;
+    rdfs:label "FULL_CONTROL"@en ;
+    rdfs:comment "Full control permission"@en .
+
+# Request Context Properties
+s3:sourceIpAddress a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:string ;
+    rdfs:label "source IP address"@en ;
+    rdfs:comment "The IP address from which the request originated"@en .
+
+s3:isSecureTransport a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:boolean ;
+    rdfs:label "is secure transport"@en ;
+    rdfs:comment "Whether the request was made over HTTPS"@en .
+
+s3:requestTime a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:dateTime ;
+    rdfs:label "request time"@en ;
+    rdfs:comment "When the request was made"@en .
+
+s3:principalArn a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:string ;
+    rdfs:label "principal ARN"@en ;
+    rdfs:comment "ARN of the principal making the request"@en .
+
+s3:principalAccount a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:string ;
+    rdfs:label "principal account"@en ;
+    rdfs:comment "Account ID of the principal"@en .
+
+s3:principalOrgId a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:string ;
+    rdfs:label "principal organization ID"@en ;
+    rdfs:comment "Organization ID of the principal"@en .
+
+s3:resourceAccount a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:string ;
+    rdfs:label "resource account"@en ;
+    rdfs:comment "Account ID that owns the resource"@en .
+
+# S3-specific condition keys
+s3:x-amz-acl a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:string ;
+    rdfs:label "x-amz-acl"@en ;
+    rdfs:comment "Canned ACL specified in request"@en .
+
+s3:x-amz-server-side-encryption a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:string ;
+    rdfs:label "x-amz-server-side-encryption"@en ;
+    rdfs:comment "Server-side encryption method"@en .
+
+s3:x-amz-storage-class a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:string ;
+    rdfs:label "x-amz-storage-class"@en ;
+    rdfs:comment "Storage class for the object"@en .
+
+s3:VersionId a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:string ;
+    rdfs:label "version ID"@en ;
+    rdfs:comment "Version ID of the object"@en .
+
+s3:prefix a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:string ;
+    rdfs:label "prefix"@en ;
+    rdfs:comment "Key name prefix for list operations"@en .
+
+s3:ExistingObjectTag a owl:ObjectProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range s3:Tag ;
+    rdfs:label "existing object tag"@en ;
+    rdfs:comment "Tags on the existing object"@en .
+
+s3:RequestObjectTag a owl:ObjectProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range s3:Tag ;
+    rdfs:label "request object tag"@en ;
+    rdfs:comment "Tags being applied in the request"@en .
+
+s3:Tag a owl:Class ;
+    rdfs:label "Tag"@en ;
+    rdfs:comment "A key-value tag"@en .
+
+s3:tagKey a owl:DatatypeProperty ;
+    rdfs:domain s3:Tag ;
+    rdfs:range xsd:string ;
+    rdfs:label "tag key"@en ;
+    rdfs:comment "The key of a tag"@en .
+
+s3:tagValue a owl:DatatypeProperty ;
+    rdfs:domain s3:Tag ;
+    rdfs:range xsd:string ;
+    rdfs:label "tag value"@en ;
+    rdfs:comment "The value of a tag"@en .
+
+# Multi-Factor Authentication
+s3:MultiFactorAuthPresent a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:boolean ;
+    rdfs:label "MFA present"@en ;
+    rdfs:comment "Whether MFA was used for authentication"@en .
+
+s3:MultiFactorAuthAge a owl:DatatypeProperty ;
+    rdfs:domain s3:RequestContext ;
+    rdfs:range xsd:integer ;
+    rdfs:label "MFA age"@en ;
+    rdfs:comment "Seconds since MFA authentication"@en .
+
+# Access Grants
+s3:AccessGrant a owl:Class ;
+    rdfs:label "Access Grant"@en ;
+    rdfs:comment "An S3 Access Grant for fine-grained permissions"@en .
+
+s3:AccessGrantsInstance a owl:Class ;
+    rdfs:label "Access Grants Instance"@en ;
+    rdfs:comment "Container for S3 Access Grants"@en .
+
+s3:AccessGrantsLocation a owl:Class ;
+    rdfs:label "Access Grants Location"@en ;
+    rdfs:comment "A registered location in Access Grants"@en .
+
+s3:hasAccessGrant a owl:ObjectProperty ;
+    rdfs:domain s3:AccessGrantsInstance ;
+    rdfs:range s3:AccessGrant ;
+    rdfs:label "has access grant"@en ;
+    rdfs:comment "Links instance to its grants"@en .
+
+s3:grantScope a owl:DatatypeProperty ;
+    rdfs:domain s3:AccessGrant ;
+    rdfs:range xsd:string ;
+    rdfs:label "grant scope"@en ;
+    rdfs:comment "The scope of the access grant"@en .
+
+# Block Public Access
+s3:BlockPublicAccess a owl:Class ;
+    rdfs:label "Block Public Access"@en ;
+    rdfs:comment "Settings to block public access"@en .
+
+s3:blockPublicAcls a owl:DatatypeProperty ;
+    rdfs:domain s3:BlockPublicAccess ;
+    rdfs:range xsd:boolean ;
+    rdfs:label "block public ACLs"@en ;
+    rdfs:comment "Block public access via ACLs"@en .
+
+s3:ignorePublicAcls a owl:DatatypeProperty ;
+    rdfs:domain s3:BlockPublicAccess ;
+    rdfs:range xsd:boolean ;
+    rdfs:label "ignore public ACLs"@en ;
+    rdfs:comment "Ignore public ACLs"@en .
+
+s3:blockPublicPolicy a owl:DatatypeProperty ;
+    rdfs:domain s3:BlockPublicAccess ;
+    rdfs:range xsd:boolean ;
+    rdfs:label "block public policy"@en ;
+    rdfs:comment "Block public bucket policies"@en .
+
+s3:restrictPublicBuckets a owl:DatatypeProperty ;
+    rdfs:domain s3:BlockPublicAccess ;
+    rdfs:range xsd:boolean ;
+    rdfs:label "restrict public buckets"@en ;
+    rdfs:comment "Restrict public bucket access"@en .
+
+# Object Ownership
+s3:ObjectOwnership a owl:Class ;
+    rdfs:label "Object Ownership"@en ;
+    rdfs:comment "Object ownership settings"@en .
+
+s3:BucketOwnerEnforced a s3:ObjectOwnership ;
+    rdfs:label "Bucket Owner Enforced"@en ;
+    rdfs:comment "Bucket owner owns all objects"@en .
+
+s3:BucketOwnerPreferred a s3:ObjectOwnership ;
+    rdfs:label "Bucket Owner Preferred"@en ;
+    rdfs:comment "Bucket owner owns objects with specific ACL"@en .
+
+s3:ObjectWriter a s3:ObjectOwnership ;
+    rdfs:label "Object Writer"@en ;
+    rdfs:comment "Uploader owns the object"@en .


### PR DESCRIPTION
Add formal RDF vocabulary and N3 rules for AWS S3 access control, and propose a unified LWS access control model with its own vocabulary and evaluation rules.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c96bf0c-e71c-418b-a171-51a5fa4aedb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c96bf0c-e71c-418b-a171-51a5fa4aedb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>