### PR TITLE
Formalize access control for cloud storage providers

### DIFF
--- a/rules/dropbox.n3
+++ b/rules/dropbox.n3
@@ -1,0 +1,24 @@
+@prefix dbx: <https://www.w3.org/ns/auth/dropbox#> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+###################################################################
+#  Simplified Dropbox permission evaluation                       #
+###################################################################
+
+# Allow when role permits action
+{
+  ?req dbx:requestedBy ?p ;
+       dbx:requestedAction ?a ;
+       dbx:requestedResource ?r .
+
+  ?r dbx:hasPermission ?perm .
+  ?perm dbx:principal ?p ;
+        dbx:role ?role .
+  ?role dbx:permits ?a .
+} => { ?req dbx:decision dbx:Allowed . } .
+
+# Default deny
+{
+  ?req a dbx:AccessRequest .
+  not { ?req dbx:decision ?d . }
+} => { ?req dbx:decision dbx:Denied . } .

--- a/rules/gdrive.n3
+++ b/rules/gdrive.n3
@@ -1,0 +1,30 @@
+@prefix gdrive: <https://www.w3.org/ns/auth/gdrive#> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+###################################################################
+#  Simplified inference rules for Google Drive permissions        #
+###################################################################
+
+# A request pattern ------------------------------------------------
+# ?req  gdrive:requestedBy       ?principal ;
+#       gdrive:requestedAction   ?action ;
+#       gdrive:requestedResource ?resource .
+# ------------------------------------------------------------------
+
+# Rule 1 – allow if a matching permission’s role allows the action --
+{
+  ?req  gdrive:requestedBy       ?p ;
+        gdrive:requestedAction   ?a ;
+        gdrive:requestedResource ?r .
+
+  ?r    gdrive:hasPermission ?perm .
+  ?perm gdrive:principal ?p ;
+        gdrive:role      ?role .
+  ?role gdrive:permits   ?a .
+} => { ?req gdrive:decision gdrive:Allowed . } .
+
+# Rule 2 – default deny -------------------------------------------
+{
+  ?req a gdrive:AccessRequest .
+  not { ?req gdrive:decision ?d . }
+} => { ?req gdrive:decision gdrive:Denied . } .

--- a/rules/icloud.n3
+++ b/rules/icloud.n3
@@ -1,0 +1,22 @@
+@prefix icloud: <https://www.w3.org/ns/auth/icloud#> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+###################################################################
+#  Simplified iCloud permission reasoning                         #
+###################################################################
+
+{
+  ?req icloud:requestedBy ?p ;
+       icloud:requestedAction ?a ;
+       icloud:requestedResource ?r .
+
+  ?r icloud:hasPermission ?perm .
+  ?perm icloud:principal ?p ;
+        icloud:role ?role .
+  ?role icloud:permits ?a .
+} => { ?req icloud:decision icloud:Allowed . } .
+
+{
+  ?req a icloud:AccessRequest .
+  not { ?req icloud:decision ?any . }
+} => { ?req icloud:decision icloud:Denied . } .

--- a/rules/mega.n3
+++ b/rules/mega.n3
@@ -1,0 +1,8 @@
+@prefix mega: <https://www.w3.org/ns/auth/mega#> .
+{ ?req mega:requestedBy ?p ; mega:requestedAction ?a ; mega:requestedResource ?r .
+  ?r mega:hasPermission ?perm .
+  ?perm mega:principal ?p ; mega:role ?role .
+  ?role mega:permits ?a .
+} => { ?req mega:decision mega:Allowed . } .
+
+{ ?req a mega:AccessRequest . not { ?req mega:decision ?d . } } => { ?req mega:decision mega:Denied . } .

--- a/rules/proton.n3
+++ b/rules/proton.n3
@@ -1,0 +1,16 @@
+@prefix proton: <https://www.w3.org/ns/auth/proton#> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+  ?req proton:requestedBy ?p ;
+       proton:requestedAction ?a ;
+       proton:requestedResource ?r .
+  ?r proton:hasPermission ?perm .
+  ?perm proton:principal ?p ; proton:role ?role .
+  ?role proton:permits ?a .
+} => { ?req proton:decision proton:Allowed . } .
+
+{
+  ?req a proton:AccessRequest .
+  not { ?req proton:decision ?d . }
+} => { ?req proton:decision proton:Denied . } .

--- a/rules/sync.n3
+++ b/rules/sync.n3
@@ -1,0 +1,8 @@
+@prefix sync: <https://www.w3.org/ns/auth/sync#> .
+{ ?req sync:requestedBy ?p ; sync:requestedAction ?a ; sync:requestedResource ?r .
+  ?r sync:hasPermission ?perm .
+  ?perm sync:principal ?p ; sync:role ?role .
+  ?role sync:permits ?a .
+} => { ?req sync:decision sync:Allowed . } .
+
+{ ?req a sync:AccessRequest . not { ?req sync:decision ?d . } } => { ?req sync:decision sync:Denied . } .

--- a/vocabs/dropbox.ttl
+++ b/vocabs/dropbox.ttl
@@ -1,0 +1,72 @@
+@prefix dbx: <https://www.w3.org/ns/auth/dropbox#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix vann: <http://purl.org/vann/> .
+
+<https://www.w3.org/ns/auth/dropbox> a owl:Ontology ;
+  rdfs:label "Dropbox Access Control Vocabulary"@en ;
+  dct:description "Key notions in Dropbox sharing & permissioning expressed as RDF for comparison in LWS."@en ;
+  vann:preferredNamespacePrefix "dbx" ;
+  vann:preferredNamespaceUri "https://www.w3.org/ns/auth/dropbox#"^^xsd:anyURI ;
+  dct:issued "2025-08-03"^^xsd:date ;
+  rdfs:seeAlso <https://help.dropbox.com/share/set-file-folder-permissions> .
+
+#########
+# CLASSES
+#########
+
+dbx:Permission a rdfs:Class ; rdfs:label "Permission"@en .
+dbx:Role       a rdfs:Class ; rdfs:label "Role"@en .
+dbx:Principal  a rdfs:Class ; rdfs:label "Principal"@en .
+dbx:User       a rdfs:Class ; rdfs:subClassOf dbx:Principal ; rdfs:label "User"@en .
+dbx:Team       a rdfs:Class ; rdfs:subClassOf dbx:Principal ; rdfs:label "Team"@en .
+dbx:Link       a rdfs:Class ; rdfs:subClassOf dbx:Principal ; rdfs:label "Shared link"@en .
+
+dbx:Resource   a rdfs:Class ; rdfs:label "Dropbox resource"@en .
+dbx:File       a rdfs:Class ; rdfs:subClassOf dbx:Resource ; rdfs:label "File"@en .
+dbx:Folder     a rdfs:Class ; rdfs:subClassOf dbx:Resource ; rdfs:label "Folder"@en .
+
+dbx:Action     a rdfs:Class .
+  dbx:View      a dbx:Action ; rdfs:label "view"@en .
+  dbx:Edit      a dbx:Action ; rdfs:label "edit"@en .
+  dbx:Comment   a dbx:Action ; rdfs:label "comment"@en .
+  dbx:Download  a dbx:Action ; rdfs:label "download"@en .
+  dbx:Upload    a dbx:Action ; rdfs:label "upload"@en .
+  dbx:Share     a dbx:Action ; rdfs:label "share"@en .
+
+dbx:AccessRequest a rdfs:Class ; rdfs:label "Access request"@en .
+
+##############
+# PROPERTIES
+##############
+
+dbx:hasPermission   a rdf:Property ; rdfs:domain dbx:Resource ; rdfs:range dbx:Permission .
+dbx:principal       a rdf:Property ; rdfs:domain dbx:Permission ; rdfs:range dbx:Principal .
+dbx:role            a rdf:Property ; rdfs:domain dbx:Permission ; rdfs:range dbx:Role .
+dbx:permits         a rdf:Property ; rdfs:domain dbx:Role ; rdfs:range dbx:Action .
+
+dbx:requestedBy      a rdf:Property ; rdfs:domain dbx:AccessRequest ; rdfs:range dbx:Principal .
+dbx:requestedAction  a rdf:Property ; rdfs:domain dbx:AccessRequest ; rdfs:range dbx:Action .
+dbx:requestedResource a rdf:Property ; rdfs:domain dbx:AccessRequest ; rdfs:range dbx:Resource .
+dbx:decision         a rdf:Property ; rdfs:domain dbx:AccessRequest .
+
+################
+# ROLE INSTANCES
+################
+
+dbx:Owner            a dbx:Role ; rdfs:label "Owner"@en .
+dbx:Editor           a dbx:Role ; rdfs:label "Editor"@en .
+dbx:Viewer           a dbx:Role ; rdfs:label "Viewer"@en .
+dbx:ViewerNoDownload a dbx:Role ; rdfs:label "Viewer (no download)"@en .
+dbx:Uploader         a dbx:Role ; rdfs:label "Uploader"@en .
+
+# Role → action matrix (simplified)
+
+dbx:Owner            dbx:permits dbx:View , dbx:Edit , dbx:Comment , dbx:Download , dbx:Upload , dbx:Share .
+dbx:Editor           dbx:permits dbx:View , dbx:Edit , dbx:Comment , dbx:Download , dbx:Share .
+dbx:Viewer           dbx:permits dbx:View , dbx:Download .
+dbx:ViewerNoDownload dbx:permits dbx:View .
+dbx:Uploader         dbx:permits dbx:Upload .

--- a/vocabs/gdrive.ttl
+++ b/vocabs/gdrive.ttl
@@ -1,0 +1,79 @@
+@prefix gdrive: <https://www.w3.org/ns/auth/gdrive#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix vann: <http://purl.org/vann/> .
+
+<https://www.w3.org/ns/auth/gdrive> a owl:Ontology ;
+  rdfs:label "Google Drive Access Control Vocabulary"@en ;
+  dct:description "Concepts in the Google Drive permission model expressed for Linked Web Storage."@en ;
+  vann:preferredNamespacePrefix "gdrive" ;
+  vann:preferredNamespaceUri "https://www.w3.org/ns/auth/gdrive#"^^xsd:anyURI ;
+  dct:issued "2025-08-03"^^xsd:date ;
+  rdfs:seeAlso <https://developers.google.com/drive/api/guides/ref-roles> .
+
+#########
+# CLASSES
+#########
+
+gdrive:Permission  a rdfs:Class ; rdfs:label "Permission"@en .
+gdrive:Role         a rdfs:Class ; rdfs:label "Role"@en .
+gdrive:Principal    a rdfs:Class ; rdfs:label "Principal"@en .
+gdrive:User         a rdfs:Class ; rdfs:subClassOf gdrive:Principal ; rdfs:label "User"@en .
+gdrive:Group        a rdfs:Class ; rdfs:subClassOf gdrive:Principal ; rdfs:label "Group"@en .
+gdrive:Domain       a rdfs:Class ; rdfs:subClassOf gdrive:Principal ; rdfs:label "Domain"@en .
+gdrive:Anyone       a rdfs:Class ; rdfs:subClassOf gdrive:Principal ; rdfs:label "Anyone"@en .
+
+gdrive:Resource     a rdfs:Class ; rdfs:label "Drive resource"@en .
+gdrive:DriveFile    a rdfs:Class ; rdfs:subClassOf gdrive:Resource ; rdfs:label "Drive file"@en .
+gdrive:DriveFolder  a rdfs:Class ; rdfs:subClassOf gdrive:Resource ; rdfs:label "Drive folder"@en .
+gdrive:SharedDrive  a rdfs:Class ; rdfs:subClassOf gdrive:Resource ; rdfs:label "Shared Drive"@en .
+
+gdrive:Action       a rdfs:Class ; rdfs:label "Action"@en .
+  gdrive:View        a gdrive:Action ; rdfs:label "view"@en .
+  gdrive:Comment     a gdrive:Action ; rdfs:label "comment"@en .
+  gdrive:Edit        a gdrive:Action ; rdfs:label "edit"@en .
+  gdrive:Organize    a gdrive:Action ; rdfs:label "organize"@en .
+  gdrive:Share       a gdrive:Action ; rdfs:label "share"@en .
+  gdrive:Delete      a gdrive:Action ; rdfs:label "delete"@en .
+
+gdrive:AccessRequest a rdfs:Class ; rdfs:label "Access request"@en .
+
+##############
+# PROPERTIES
+##############
+
+gdrive:hasPermission    a rdf:Property ; rdfs:domain gdrive:Resource ; rdfs:range gdrive:Permission ; rdfs:label "has permission"@en .
+gdrive:principal        a rdf:Property ; rdfs:domain gdrive:Permission ; rdfs:range gdrive:Principal ; rdfs:label "principal"@en .
+gdrive:role             a rdf:Property ; rdfs:domain gdrive:Permission ; rdfs:range gdrive:Role ; rdfs:label "role"@en .
+gdrive:permits          a rdf:Property ; rdfs:domain gdrive:Role ; rdfs:range gdrive:Action ; rdfs:label "permits"@en .
+
+gdrive:requestedBy      a rdf:Property ; rdfs:domain gdrive:AccessRequest ; rdfs:range gdrive:Principal .
+gdrive:requestedAction  a rdf:Property ; rdfs:domain gdrive:AccessRequest ; rdfs:range gdrive:Action .
+gdrive:requestedResource a rdf:Property ; rdfs:domain gdrive:AccessRequest ; rdfs:range gdrive:Resource .
+gdrive:decision         a rdf:Property ; rdfs:domain gdrive:AccessRequest ; rdfs:label "decision"@en .
+
+################
+# ROLE INSTANCES
+################
+
+gdrive:Owner           a gdrive:Role ; rdfs:label "Owner"@en .
+gdrive:Organizer       a gdrive:Role ; rdfs:label "Organizer"@en .
+gdrive:FileOrganizer   a gdrive:Role ; rdfs:label "File Organizer"@en .
+gdrive:Writer          a gdrive:Role ; rdfs:label "Writer"@en .
+gdrive:Commenter       a gdrive:Role ; rdfs:label "Commenter"@en .
+gdrive:Reader          a gdrive:Role ; rdfs:label "Reader"@en .
+gdrive:PublishedReader a gdrive:Role ; rdfs:label "Published reader"@en .
+
+# Simplified role → action matrix
+#gdrive:permits is additive – a role that permits a superset of actions implicitly permits lower-level actions.
+
+gdrive:Owner           gdrive:permits gdrive:View , gdrive:Comment , gdrive:Edit , gdrive:Organize , gdrive:Share , gdrive:Delete .
+gdrive:Organizer       gdrive:permits gdrive:View , gdrive:Comment , gdrive:Edit , gdrive:Organize , gdrive:Share .
+gdrive:FileOrganizer   gdrive:permits gdrive:View , gdrive:Comment , gdrive:Edit , gdrive:Organize .
+gdrive:Writer          gdrive:permits gdrive:View , gdrive:Comment , gdrive:Edit .
+gdrive:Commenter       gdrive:permits gdrive:View , gdrive:Comment .
+gdrive:Reader          gdrive:permits gdrive:View .
+gdrive:PublishedReader gdrive:permits gdrive:View .

--- a/vocabs/icloud.ttl
+++ b/vocabs/icloud.ttl
@@ -1,0 +1,54 @@
+@prefix icloud: <https://www.w3.org/ns/auth/icloud#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix vann: <http://purl.org/vann/> .
+
+<https://www.w3.org/ns/auth/icloud> a owl:Ontology ;
+  rdfs:label "iCloud Drive Access Control Vocabulary"@en ;
+  dct:description "Simplified representation of iCloud Drive collaborative sharing roles."@en ;
+  vann:preferredNamespacePrefix "icloud" ;
+  vann:preferredNamespaceUri "https://www.w3.org/ns/auth/icloud#"^^xsd:anyURI ;
+  dct:issued "2025-08-03"^^xsd:date ;
+  rdfs:seeAlso <https://support.apple.com/guide/icloud/share-and-collaborate-iclu1949ee4a/web> .
+
+icloud:Permission a rdfs:Class ; rdfs:label "Permission"@en .
+icloud:Role       a rdfs:Class ; rdfs:label "Role"@en .
+icloud:Principal  a rdfs:Class ; rdfs:label "Principal"@en .
+icloud:User       a rdfs:Class ; rdfs:subClassOf icloud:Principal .
+icloud:LinkGuest  a rdfs:Class ; rdfs:subClassOf icloud:Principal ; rdfs:label "Anyone with link"@en .
+
+icloud:Resource a rdfs:Class ; rdfs:label "iCloud resource"@en .
+icloud:File     a rdfs:Class ; rdfs:subClassOf icloud:Resource .
+icloud:Folder   a rdfs:Class ; rdfs:subClassOf icloud:Resource .
+
+icloud:Action   a rdfs:Class .
+  icloud:View   a icloud:Action ; rdfs:label "view"@en .
+  icloud:Edit   a icloud:Action ; rdfs:label "edit"@en .
+  icloud:Upload a icloud:Action ; rdfs:label "upload"@en .
+  icloud:Share  a icloud:Action ; rdfs:label "share"@en .
+
+icloud:AccessRequest a rdfs:Class .
+
+icloud:hasPermission a rdf:Property ; rdfs:domain icloud:Resource ; rdfs:range icloud:Permission .
+icloud:principal     a rdf:Property ; rdfs:domain icloud:Permission ; rdfs:range icloud:Principal .
+icloud:role          a rdf:Property ; rdfs:domain icloud:Permission ; rdfs:range icloud:Role .
+icloud:permits       a rdf:Property ; rdfs:domain icloud:Role ; rdfs:range icloud:Action .
+icloud:requestedBy   a rdf:Property ; rdfs:domain icloud:AccessRequest ; rdfs:range icloud:Principal .
+icloud:requestedAction a rdf:Property ; rdfs:domain icloud:AccessRequest ; rdfs:range icloud:Action .
+icloud:requestedResource a rdf:Property ; rdfs:domain icloud:AccessRequest ; rdfs:range icloud:Resource .
+icloud:decision      a rdf:Property ; rdfs:domain icloud:AccessRequest .
+
+# Roles
+icloud:Owner             a icloud:Role ; rdfs:label "Owner"@en .
+icloud:ParticipantRW     a icloud:Role ; rdfs:label "Participant (read-write)"@en .
+icloud:ParticipantRO     a icloud:Role ; rdfs:label "Participant (read-only)"@en .
+icloud:PublicLinkViewer  a icloud:Role ; rdfs:label "Anyone (view)"@en .
+
+# Role action matrix
+icloud:Owner         icloud:permits icloud:View , icloud:Edit , icloud:Upload , icloud:Share .
+icloud:ParticipantRW icloud:permits icloud:View , icloud:Edit , icloud:Upload .
+icloud:ParticipantRO icloud:permits icloud:View .
+icloud:PublicLinkViewer icloud:permits icloud:View .

--- a/vocabs/mega.ttl
+++ b/vocabs/mega.ttl
@@ -1,0 +1,51 @@
+@prefix mega: <https://www.w3.org/ns/auth/mega#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix vann: <http://purl.org/vann/> .
+
+<https://www.w3.org/ns/auth/mega> a owl:Ontology ;
+  rdfs:label "MEGA.nz Permission Vocabulary"@en ;
+  dct:description "Roles for folder sharing in MEGA.nz (full, read-write, read-only)."@en ;
+  vann:preferredNamespacePrefix "mega" ;
+  vann:preferredNamespaceUri "https://www.w3.org/ns/auth/mega#"^^xsd:anyURI ;
+  dct:issued "2025-08-03"^^xsd:date ;
+  rdfs:seeAlso <https://help.mega.nz/hc/en-us/articles/360042487013-Permissions-for-shared-folders> .
+
+mega:Permission a rdfs:Class .
+mega:Role a rdfs:Class .
+mega:Principal a rdfs:Class .
+mega:User a rdfs:Class ; rdfs:subClassOf mega:Principal .
+mega:LinkGuest a rdfs:Class ; rdfs:subClassOf mega:Principal .
+
+mega:Resource a rdfs:Class .
+mega:File a rdfs:Class ; rdfs:subClassOf mega:Resource .
+mega:Folder a rdfs:Class ; rdfs:subClassOf mega:Resource .
+
+mega:Action a rdfs:Class .
+  mega:View a mega:Action .
+  mega:Edit a mega:Action .
+  mega:Upload a mega:Action .
+  mega:Share a mega:Action .
+
+mega:AccessRequest a rdfs:Class .
+
+mega:hasPermission a rdf:Property ; rdfs:domain mega:Resource ; rdfs:range mega:Permission .
+mega:principal a rdf:Property ; rdfs:domain mega:Permission ; rdfs:range mega:Principal .
+mega:role a rdf:Property ; rdfs:domain mega:Permission ; rdfs:range mega:Role .
+mega:permits a rdf:Property ; rdfs:domain mega:Role ; rdfs:range mega:Action .
+
+mega:requestedBy a rdf:Property ; rdfs:domain mega:AccessRequest ; rdfs:range mega:Principal .
+mega:requestedAction a rdf:Property ; rdfs:domain mega:AccessRequest ; rdfs:range mega:Action .
+mega:requestedResource a rdf:Property ; rdfs:domain mega:AccessRequest ; rdfs:range mega:Resource .
+mega:decision a rdf:Property ; rdfs:domain mega:AccessRequest .
+
+mega:FullAccess a mega:Role .
+mega:ReadWrite a mega:Role .
+mega:ReadOnly a mega:Role .
+
+mega:FullAccess mega:permits mega:View , mega:Edit , mega:Upload , mega:Share .
+mega:ReadWrite mega:permits mega:View , mega:Edit , mega:Upload .
+mega:ReadOnly mega:permits mega:View .

--- a/vocabs/proton.ttl
+++ b/vocabs/proton.ttl
@@ -1,0 +1,55 @@
+@prefix proton: <https://www.w3.org/ns/auth/proton#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix vann: <http://purl.org/vann/> .
+
+<https://www.w3.org/ns/auth/proton> a owl:Ontology ;
+  rdfs:label "Proton Drive Access Control Vocabulary"@en ;
+  dct:description "Vocabulary capturing Proton Drive share link & collaborator roles."@en ;
+  vann:preferredNamespacePrefix "proton" ;
+  vann:preferredNamespaceUri "https://www.w3.org/ns/auth/proton#"^^xsd:anyURI ;
+  dct:issued "2025-08-03"^^xsd:date ;
+  rdfs:seeAlso <https://proton.me/support/share-files-folders-proton-drive> .
+
+proton:Permission a rdfs:Class .
+proton:Role       a rdfs:Class .
+proton:Principal  a rdfs:Class .
+proton:User       a rdfs:Class ; rdfs:subClassOf proton:Principal .
+proton:LinkGuest  a rdfs:Class ; rdfs:subClassOf proton:Principal .
+
+proton:Resource   a rdfs:Class .
+proton:File       a rdfs:Class ; rdfs:subClassOf proton:Resource .
+proton:Folder     a rdfs:Class ; rdfs:subClassOf proton:Resource .
+
+proton:Action a rdfs:Class .
+  proton:View   a proton:Action .
+  proton:Edit   a proton:Action .
+  proton:Upload a proton:Action .
+  proton:Share  a proton:Action .
+
+proton:AccessRequest a rdfs:Class .
+
+# Properties
+proton:hasPermission a rdf:Property ; rdfs:domain proton:Resource ; rdfs:range proton:Permission .
+proton:principal     a rdf:Property ; rdfs:domain proton:Permission ; rdfs:range proton:Principal .
+proton:role          a rdf:Property ; rdfs:domain proton:Permission ; rdfs:range proton:Role .
+proton:permits       a rdf:Property ; rdfs:domain proton:Role ; rdfs:range proton:Action .
+proton:requestedBy   a rdf:Property ; rdfs:domain proton:AccessRequest ; rdfs:range proton:Principal .
+proton:requestedAction a rdf:Property ; rdfs:domain proton:AccessRequest ; rdfs:range proton:Action .
+proton:requestedResource a rdf:Property ; rdfs:domain proton:AccessRequest ; rdfs:range proton:Resource .
+proton:decision      a rdf:Property ; rdfs:domain proton:AccessRequest .
+
+# Roles
+proton:Owner   a proton:Role .
+proton:Editor  a proton:Role .
+proton:Viewer  a proton:Role .
+proton:LinkViewer a proton:Role .
+
+# Matrix
+proton:Owner  proton:permits proton:View , proton:Edit , proton:Upload , proton:Share .
+proton:Editor proton:permits proton:View , proton:Edit , proton:Upload .
+proton:Viewer proton:permits proton:View .
+proton:LinkViewer proton:permits proton:View .

--- a/vocabs/sync.ttl
+++ b/vocabs/sync.ttl
@@ -1,0 +1,51 @@
+@prefix sync: <https://www.w3.org/ns/auth/sync#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix vann: <http://purl.org/vann/> .
+
+<https://www.w3.org/ns/auth/sync> a owl:Ontology ;
+  rdfs:label "Sync.com Permission Vocabulary"@en ;
+  dct:description "Simplified Sync.com share permissions for LWS comparison."@en ;
+  vann:preferredNamespacePrefix "sync" ;
+  vann:preferredNamespaceUri "https://www.w3.org/ns/auth/sync#"^^xsd:anyURI ;
+  dct:issued "2025-08-03"^^xsd:date ;
+  rdfs:seeAlso <https://help.sync.com/hc/en-us/articles/360029065271-Permissions-explained> .
+
+sync:Permission a rdfs:Class .
+sync:Role a rdfs:Class .
+sync:Principal a rdfs:Class .
+sync:User a rdfs:Class ; rdfs:subClassOf sync:Principal .
+
+sync:Resource a rdfs:Class .
+sync:File a rdfs:Class ; rdfs:subClassOf sync:Resource .
+sync:Folder a rdfs:Class ; rdfs:subClassOf sync:Resource .
+
+sync:Action a rdfs:Class .
+  sync:View a sync:Action .
+  sync:Edit a sync:Action .
+  sync:Upload a sync:Action .
+  sync:Share a sync:Action .
+
+sync:AccessRequest a rdfs:Class .
+
+sync:hasPermission a rdf:Property ; rdfs:domain sync:Resource ; rdfs:range sync:Permission .
+sync:principal a rdf:Property ; rdfs:domain sync:Permission ; rdfs:range sync:Principal .
+sync:role      a rdf:Property ; rdfs:domain sync:Permission ; rdfs:range sync:Role .
+sync:permits   a rdf:Property ; rdfs:domain sync:Role ; rdfs:range sync:Action .
+
+sync:requestedBy a rdf:Property ; rdfs:domain sync:AccessRequest ; rdfs:range sync:Principal .
+sync:requestedAction a rdf:Property ; rdfs:domain sync:AccessRequest ; rdfs:range sync:Action .
+sync:requestedResource a rdf:Property ; rdfs:domain sync:AccessRequest ; rdfs:range sync:Resource .
+sync:decision a rdf:Property ; rdfs:domain sync:AccessRequest .
+
+# Roles
+sync:Owner a sync:Role .
+sync:Editor a sync:Role .
+sync:Viewer a sync:Role .
+
+sync:Owner sync:permits sync:View , sync:Edit , sync:Upload , sync:Share .
+sync:Editor sync:permits sync:View , sync:Edit , sync:Upload .
+sync:Viewer sync:permits sync:View .


### PR DESCRIPTION
Adds RDF vocabularies and N3 rules for access control models of Google Drive, Dropbox, iCloud, Proton, Sync, and MEGA.nz to enable comparative analysis for the LWS specification.

---
<a href="https://cursor.com/background-agent?bcId=bc-af8ad6f3-1396-44b3-97bb-4a2c3b8b0481">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af8ad6f3-1396-44b3-97bb-4a2c3b8b0481">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>